### PR TITLE
Workaround a `-dcore-lint` bug in GHC 7.6/7.7

### DIFF
--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -114,16 +114,16 @@ instance Prim ty where {                                        \
                         { (# s1#, x# #) -> (# s1#, ctr x# #) }  \
 ; writeByteArray# arr# i# (ctr x#) s# = wr_arr arr# i# x# s#    \
 ; setByteArray# arr# i# n# (ctr x#) s#                          \
-    = case internal (set_arr arr# i# n# x#) (unsafeCoerce# s#) of \
-        { (# s1#, _ #) -> unsafeCoerce# s1# }                   \
+    = case unsafeCoerce# (internal (set_arr arr# i# n# x#)) s# of \
+        { (# s1#, _ #) -> s1# }                                 \
                                                                 \
 ; indexOffAddr# addr# i# = ctr (idx_addr addr# i#)              \
 ; readOffAddr#  addr# i# s# = case rd_addr addr# i# s# of       \
                         { (# s1#, x# #) -> (# s1#, ctr x# #) }  \
 ; writeOffAddr# addr# i# (ctr x#) s# = wr_addr addr# i# x# s#   \
 ; setOffAddr# addr# i# n# (ctr x#) s#                           \
-    = case internal (set_addr addr# i# n# x#) (unsafeCoerce# s#) of \
-        { (# s1#, _ #) -> unsafeCoerce# s1# }                   \
+    = case unsafeCoerce# (internal (set_addr addr# i# n# x#)) s# of \
+        { (# s1#, _ #) -> s1# }                                 \
 ; {-# INLINE sizeOf# #-}                                        \
 ; {-# INLINE alignment# #-}                                     \
 ; {-# INLINE indexByteArray# #-}                                \


### PR DESCRIPTION
When compiled with `-dcore-lint`, GHC 7.6/7.7 bails out with a Core lint error;
The workaround/fix used in this commit based on a suggestion given by @simonmar
in GHC #7643.

See also http://ghc.haskell.org/trac/ghc/ticket/8355 for more details.
