### PR TITLE
fix compilation on Solaris 10 with GNU C 3.4.3

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -44,7 +44,9 @@ Library
   Install-Includes: primitive-memops.h
   includes: primitive-memops.h
   c-sources: cbits/primitive-memops.c
-  cc-options: -O3 -ftree-vectorize -fomit-frame-pointer -Wall
+  cc-options: -O3 -fomit-frame-pointer -Wall
+  if !os(solaris)
+      cc-options: -ftree-vectorize
   if arch(i386) || arch(x86_64)
       cc-options: -msse2
 


### PR DESCRIPTION
This patch fixes compilation on Solaris 10 platform which provides
GNU C 3.4.3 by default by removing unsupported -ftree-vectorize option.
This may penalize Solaris 11, where GNU C 4.6.2 is provided but current
cabal does not support OSes version detection and Solaris 10 is still
supported (by Oracle) and will be at least till 2021 so let's support it
too.
