### PR TITLE
Condition runST import in Data/Primitive/Array.hs

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -29,7 +29,9 @@ import Data.Typeable ( Typeable )
 import Data.Data ( Data(..) )
 import Data.Primitive.Internal.Compat ( isTrue#, mkNoRepType )
 
+#if !(__GLASGOW_HASKELL__ >= 702)
 import Control.Monad.ST(runST)
+#endif
 
 -- | Boxed arrays
 data Array a = Array (Array# a) deriving ( Typeable )


### PR DESCRIPTION
runST is not used in this file on GHC 7.2.x and higher, hence importing
it from Control.Monad.ST produces a warning during compilation.  This
commit makes the warning go away.