### PR TITLE
Use size_t and ptrdiff_t instead of int in cbits

### DIFF
--- a/cbits/primitive-memops.c
+++ b/cbits/primitive-memops.c
@@ -1,18 +1,18 @@
 #include <string.h>
 #include "primitive-memops.h"
 
-void hsprimitive_memcpy( void *dst, int doff, void *src, int soff, size_t len )
+void hsprimitive_memcpy( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len )
 {
   memcpy( (char *)dst + doff, (char *)src + soff, len );
 }
 
-void hsprimitive_memmove( void *dst, int doff, void *src, int soff, size_t len )
+void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len )
 {
   memmove( (char *)dst + doff, (char *)src + soff, len );
 }
 
 #define MEMSET(TYPE, ATYPE)                                                  \
-void hsprimitive_memset_ ## TYPE (Hs ## TYPE *p, int off, int n, ATYPE x)    \
+void hsprimitive_memset_ ## TYPE (Hs ## TYPE *p, ptrdiff_t off, size_t n, ATYPE x) \
 {                                                                            \
   p += off;                                                                  \
   if (x == 0)                                                                \
@@ -35,7 +35,7 @@ void hsprimitive_memset_ ## TYPE (Hs ## TYPE *p, int off, int n, ATYPE x)    \
   }                                                                          \
 }
 
-void hsprimitive_memset_Word8 (HsWord8 *p, int off, int n, HsWord x)
+void hsprimitive_memset_Word8 (HsWord8 *p, ptrdiff_t off, size_t n, HsWord x)
 {
   memset( (char *)(p+off), x, n );
 }

--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -2,20 +2,21 @@
 #define haskell_primitive_memops_h
 
 #include <stdlib.h>
+#include <stddef.h>
 #include <HsFFI.h>
 
-void hsprimitive_memcpy( void *dst, int doff, void *src, int soff, size_t len );
-void hsprimitive_memmove( void *dst, int doff, void *src, int soff, size_t len );
+void hsprimitive_memcpy( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
+void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
 
-void hsprimitive_memset_Word8 (HsWord8 *, int, int, HsWord);
-void hsprimitive_memset_Word16 (HsWord16 *, int, int, HsWord);
-void hsprimitive_memset_Word32 (HsWord32 *, int, int, HsWord);
-void hsprimitive_memset_Word64 (HsWord64 *, int, int, HsWord64);
-void hsprimitive_memset_Word (HsWord *, int, int, HsWord);
-void hsprimitive_memset_Ptr (HsPtr *, int, int, HsPtr);
-void hsprimitive_memset_Float (HsFloat *, int, int, HsFloat);
-void hsprimitive_memset_Double (HsDouble *, int, int, HsDouble);
-void hsprimitive_memset_Char (HsChar *, int, int, HsChar);
+void hsprimitive_memset_Word8 (HsWord8 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word16 (HsWord16 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word32 (HsWord32 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word64 (HsWord64 *, ptrdiff_t, size_t, HsWord64);
+void hsprimitive_memset_Word (HsWord *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Ptr (HsPtr *, ptrdiff_t, size_t, HsPtr);
+void hsprimitive_memset_Float (HsFloat *, ptrdiff_t, size_t, HsFloat);
+void hsprimitive_memset_Double (HsDouble *, ptrdiff_t, size_t, HsDouble);
+void hsprimitive_memset_Char (HsChar *, ptrdiff_t, size_t, HsChar);
 
 #endif
 


### PR DESCRIPTION
The current implementation overflows if you try to memset a large enough array (2^32 or greater).