### PR TITLE
Minor documentation clarification

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -10,7 +10,7 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Primitive boxed arrays
+-- Primitive arrays of boxed values.
 --
 
 module Data.Primitive.Array (


### PR DESCRIPTION
With the original text it was not 100% clear whether the array was boxed of the values. New text makes it explicit that its the values that are boxed.
