### PR TITLE
Bump upper bound on base

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -45,7 +45,7 @@ Library
         Data.Primitive.Internal.Compat
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.5 && < 4.10
+  Build-Depends: base >= 4.5 && < 4.11
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
 


### PR DESCRIPTION
base 4.10 will ship with GHC 8.2.1.