### PR TITLE
add PrimArray, Arr class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
           $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
    fi
  - travis_retry cabal update -v
+ - cabal install cpphs
  - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
  - cabal new-build ${TEST} ${BENCH} --dep
 

--- a/Data/Primitive/Addr.hs
+++ b/Data/Primitive/Addr.hs
@@ -22,7 +22,10 @@ module Data.Primitive.Addr (
   indexOffAddr, readOffAddr, writeOffAddr,
 
   -- * Block operations
-  copyAddr, moveAddr, setAddr
+  copyAddr, moveAddr, setAddr,
+
+  -- * Cast between 'Ptr'
+  castAddrToPtr, castPtrToAddr
 ) where
 
 import Control.Monad.Primitive
@@ -100,3 +103,10 @@ setAddr :: (Prim a, PrimMonad m) => Addr -> Int -> a -> m ()
 {-# INLINE setAddr #-}
 setAddr (Addr addr#) (I# n#) x = primitive_ (setOffAddr# addr# 0# n# x)
 
+-- | Cast 'Addr' to 'Ptr'.
+castAddrToPtr :: Addr -> Ptr a
+castAddrToPtr (Addr addr#) = Ptr addr#
+
+-- | Cast 'Addr' from 'Ptr'.
+castPtrToAddr :: Ptr a -> Addr
+castPtrToAddr (Ptr addr#) = Addr addr#

--- a/Data/Primitive/Array/Checked.hs
+++ b/Data/Primitive/Array/Checked.hs
@@ -70,7 +70,7 @@ import GHC.Ptr (Ptr(..))
 
 check :: String -> Bool -> a -> a
 check _      True  x = x
-check errMsg False _ = throw (IndexOutOfBounds $ "Data.Array.Checked." ++ errMsg)
+check errMsg False _ = throw (IndexOutOfBounds $ "Data.Primitive.Array.Checked." ++ errMsg)
 {-# INLINE check #-}
 
 newArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => Int -> m (marr s a)

--- a/Data/Primitive/Array/Checked.hs
+++ b/Data/Primitive/Array/Checked.hs
@@ -1,0 +1,225 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{-|
+Module      : Data.Array.Checked
+Description : Bounded checked boxed and unboxed arrays
+Copyright   : (c) Winter, 2017
+License     : BSD3
+Maintainer  : libraries@haskell.org, drkoster@qq.com
+
+Stability   : experimental
+Portability : non-portable
+
+This module provides exactly the same API with "Data.Primitive.Array.Class", but will throw an 'IndexOutOfBounds'
+'ArrayException' on bound check failure.
+
+-}
+module Data.Primitive.Array.Checked
+  ( -- * Arr typeclass re-export
+    A.Arr
+  , RealWorld
+    -- * Bound checked array operations
+  , newArr
+  , newArrWith
+  , readArr
+  , writeArr
+  , setArr
+  , indexArr
+  , indexArrM
+  , freezeArr
+  , thawArr
+  , copyArr
+  , copyMutableArr
+  , moveArr
+  , cloneArr
+  , cloneMutableArr
+  , resizeMutableArr
+  , shrinkMutableArr
+  -- * No bound checked operations
+  , A.unsafeFreezeArr
+  , A.unsafeThawArr
+  , A.sameMutableArr
+  , A.sizeofArr
+  , A.sizeofMutableArr
+  , A.sameArr
+  -- * Boxed array type
+  , A.Array(..)
+  , A.MutableArray(..)
+  , A.SmallArray(..)
+  , A.SmallMutableArray(..)
+  , A.uninitialized
+  -- * Primitive array type
+  , A.PrimArray(..)
+  , A.MutablePrimArray(..)
+  , A.newPinnedPrimArray, A.newAlignedPinnedPrimArray
+  -- * Bound checked primitive array operations
+  , copyPrimArrayToPtr, copyMutablePrimArrayToPtr, copyMutablePrimArrayFromPtr
+  -- * Unlifted array type
+  , A.UnliftedArray(..)
+  , A.MutableUnliftedArray(..)
+  , A.PrimUnlifted(..)
+  -- * The 'ArrayException' type
+  , ArrayException(..)
+  ) where
+
+import qualified Data.Primitive.Array.Class as A
+import Control.Exception (throw, ArrayException(..))
+import Control.Monad.Primitive
+import Data.Primitive.Types
+import GHC.Ptr (Ptr(..))
+
+check :: String -> Bool -> a -> a
+check _      True  x = x
+check errMsg False _ = throw (IndexOutOfBounds $ "Data.Array.Checked." ++ errMsg)
+{-# INLINE check #-}
+
+newArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => Int -> m (marr s a)
+newArr n = check "newArr: negative size" (n>=0) (A.newArr n)
+{-# INLINE newArr #-}
+
+newArrWith :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => Int -> a -> m (marr s a)
+newArrWith n x = check "newArrWith: negative size" (n>=0) (A.newArrWith n x)
+{-# INLINE newArrWith #-}
+
+readArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m a
+readArr marr i = do
+    siz <- A.sizeofMutableArr marr
+    check "readArr: index of out bounds"
+        (i>=0 && i<siz)
+        (A.readArr marr i)
+{-# INLINE readArr #-}
+
+writeArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> a -> m ()
+writeArr marr i x = do
+    siz <- A.sizeofMutableArr marr
+    check "writeArr: index of out bounds"
+        (i>=0 && i<siz)
+        (A.writeArr marr i x)
+{-# INLINE writeArr #-}
+
+setArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> a -> m ()
+setArr marr s l x = do
+    siz <- A.sizeofMutableArr marr
+    check "setArr: index range of out bounds"
+        (s>=0 && l>=0 && (s+l)<=siz)
+        (A.setArr marr s l x)
+{-# INLINE setArr #-}
+
+indexArr :: (A.Arr marr arr a) => arr a -> Int -> a
+indexArr arr i = check "indexArr: index of out bounds"
+    (i>=0 && i<A.sizeofArr arr)
+    (A.indexArr arr i)
+{-# INLINE indexArr #-}
+
+indexArrM :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => arr a -> Int -> m a
+indexArrM arr i = check "indexArrM: index of out bounds"
+    (i>=0 && i<A.sizeofArr arr)
+    (A.indexArrM arr i)
+{-# INLINE indexArrM #-}
+
+freezeArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> m (arr a)
+freezeArr marr s l = do
+    siz <- A.sizeofMutableArr marr
+    check "freezeArr: index range of out bounds"
+        (s>=0 && l>=0 && (s+l)<=siz)
+        (A.freezeArr marr s l)
+{-# INLINE freezeArr #-}
+
+thawArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => arr a -> Int -> Int -> m (marr s a)
+thawArr arr s l = check "thawArr: index range of out bounds"
+    (s>=0 && l>=0 && (s+l)<=A.sizeofArr arr)
+    (A.thawArr arr s l)
+{-# INLINE thawArr #-}
+
+copyArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> arr a -> Int -> Int -> m ()
+copyArr marr s1 arr s2 l = do
+    siz <- A.sizeofMutableArr marr
+    check "copyArr: index range of out bounds"
+        (s1>=0 && s2>=0 && l>=0 && (s2+l)<=A.sizeofArr arr && (s1+l)<=siz)
+        (A.copyArr marr s1 arr s2 l)
+{-# INLINE copyArr #-}
+
+copyMutableArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> marr s a -> Int -> Int -> m ()
+copyMutableArr marr1 s1 marr2 s2 l = do
+    siz1 <- A.sizeofMutableArr marr1
+    siz2 <- A.sizeofMutableArr marr2
+    check "copyMutableArr: index range of out bounds"
+        (s1>=0 && s2>=0 && l>=0 && (s2+l)<=siz2 && (s1+l)<=siz1)
+        (A.copyMutableArr marr1 s1 marr2 s2 l)
+{-# INLINE copyMutableArr #-}
+
+moveArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> marr s a -> Int -> Int -> m ()
+moveArr marr1 s1 marr2 s2 l = do
+    siz1 <- A.sizeofMutableArr marr1
+    siz2 <- A.sizeofMutableArr marr2
+    check "moveArr: index range of out bounds"
+        (s1>=0 && s2>=0 && l>=0 && (s2+l)<=siz2 && (s1+l)<=siz1)
+        (A.copyMutableArr marr1 s1 marr2 s2 l)
+{-# INLINE moveArr #-}
+
+cloneArr :: (A.Arr marr arr a) => arr a -> Int -> Int -> arr a
+cloneArr arr s l = check "cloneArr: index range of out bounds"
+    (s>=0 && l>=0 && (s+l)<=A.sizeofArr arr)
+    (A.cloneArr arr s l)
+{-# INLINE cloneArr #-}
+
+cloneMutableArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> m (marr s a)
+cloneMutableArr marr s l = do
+    siz <- A.sizeofMutableArr marr
+    check "cloneMutableArr: index range of out bounds"
+        (s>=0 && l>=0 && (s+l)<=siz)
+        (A.cloneMutableArr marr s l)
+{-# INLINE cloneMutableArr #-}
+
+resizeMutableArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m (marr s a)
+resizeMutableArr marr n = check "resizeMutableArr: negative index"
+    (n>=0)
+    (A.resizeMutableArr marr n)
+{-# INLINE resizeMutableArr #-}
+
+-- | New size should be >= 0, and <= original size.
+--
+shrinkMutableArr :: (A.Arr marr arr a, PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m ()
+shrinkMutableArr marr n = do
+    siz <- A.sizeofMutableArr marr
+    check "shrinkMutableArr: size out of bounds"
+        (n>=0 && n<=siz)
+        (A.shrinkMutableArr marr n)
+{-# INLINE shrinkMutableArr #-}
+
+copyPrimArrayToPtr :: (PrimMonad m, Prim a)
+                   => Ptr a
+                   -> A.PrimArray a
+                   -> Int
+                   -> Int
+                   -> m ()
+{-# INLINE copyPrimArrayToPtr #-}
+copyPrimArrayToPtr ptr arr s l = check "copyPrimArrayToPtr: index range out of bounds"
+    (s>=0 && l>=0 && (s+l)<=A.sizeofArr arr)
+    (A.copyPrimArrayToPtr ptr arr s l)
+
+copyMutablePrimArrayToPtr :: (PrimMonad m, Prim a)
+                          => Ptr a
+                          -> A.MutablePrimArray (PrimState m) a
+                          -> Int
+                          -> Int
+                          -> m ()
+{-# INLINE copyMutablePrimArrayToPtr #-}
+copyMutablePrimArrayToPtr ptr marr s l = do
+    siz <- A.sizeofMutableArr marr
+    check "copyMutablePrimArrayToPtr: index range out of bounds"
+        (s>=0 && l>=0 && (s+l)<=siz)
+        (A.copyMutablePrimArrayToPtr ptr marr s l)
+
+copyMutablePrimArrayFromPtr :: (PrimMonad m, Prim a)
+                            => A.MutablePrimArray (PrimState m) a
+                            -> Int
+                            -> Ptr a
+                            -> Int
+                            -> m ()
+{-# INLINE copyMutablePrimArrayFromPtr #-}
+copyMutablePrimArrayFromPtr marr s ptr l = do
+    siz <- A.sizeofMutableArr marr
+    check "copyMutablePrimArrayFromPtr: index range out of bounds"
+        (s>=0 && l>=0 && (s+l)<=siz)
+        (A.copyMutablePrimArrayFromPtr marr s ptr l)

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -319,11 +319,13 @@ instance Arr SmallMutableArray SmallArray a where
     shrinkMutableArr _ _ = return ()
     {-# INLINE shrinkMutableArr #-}
 
-    sameMutableArr (SmallMutableArray smarr1#) (SmallMutableArray smarr2#) = isTrue#
 #if HAVE_SMALL_ARRAY
+    sameMutableArr (SmallMutableArray smarr1#) (SmallMutableArray smarr2#) = isTrue#
         (sameSmallMutableArray# smarr1# smarr2#)
 #else
-        (sameMutableArray# smarr1# smarr2#)
+    sameMutableArr (SmallMutableArray (MutableArray smarr1#))
+                   (SmallMutableArray (MutableArray smarr2#)) = isTrue#
+                        (sameMutableArray# smarr1# smarr2#)
 #endif
     {-# INLINE sameMutableArr #-}
 
@@ -332,10 +334,11 @@ instance Arr SmallMutableArray SmallArray a where
     sizeofMutableArr = return . sizeofSmallMutableArray
     {-# INLINE sizeofMutableArr #-}
 
-    sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue#
 #if HAVE_SMALL_ARRAY
+    sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue#
         (sameSmallMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
 #else
+    sameArr (SmallArray (Array arr1#)) (SmallArray (Array arr2#)) = isTrue#
         (sameMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
 #endif
     {-# INLINE sameArr #-}

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -427,8 +427,8 @@ instance PrimUnlifted a => Arr MutableUnliftedArray UnliftedArray a where
     unsafeFreezeArr = unsafeFreezeUnliftedArray
     {-# INLINE unsafeFreezeArr #-}
     unsafeThawArr (UnliftedArray arr#) = primitive ( \ s0# ->
-            let (# s1#, marr# #) = unsafeThawArray# (unsafeCoerce# arr#) s0#  -- ArrayArray# and Array# use the same representation
-            in (# s1#, MutableUnliftedArray (unsafeCoerce# marr#) #)          -- so this works
+            let !(# s1#, marr# #) = unsafeThawArray# (unsafeCoerce# arr#) s0#   -- ArrayArray# and Array# use the same representation
+            in (# s1#, MutableUnliftedArray (unsafeCoerce# marr#) #)            -- so this works
         )
     {-# INLINE unsafeThawArr #-}
 

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -142,7 +142,7 @@ class Arr (marr :: * -> * -> *) (arr :: * -> * ) a | arr -> marr, marr -> arr wh
 
     -- | Shrink a mutable array to the given size.
     --
-    -- This operation is not guaranteed to have effects, e.g. 'sizeOfMutableArr' will not change.
+    -- This operation is not guaranteed to have effects, e.g. 'sizeOfMutableArr' may not change.
     -- It's mainly used to optimize GC of arrays which contain unused elements.
     shrinkMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m ()
 

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -248,7 +248,6 @@ instance Arr MutableArray Array a where
         sameMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
     {-# INLINE sameArr #-}
 
-#if HAVE_SMALL_ARRAY
 instance Arr SmallMutableArray SmallArray a where
     newArr n = newSmallArray n uninitialized
     {-# INLINE newArr #-}
@@ -320,18 +319,26 @@ instance Arr SmallMutableArray SmallArray a where
     shrinkMutableArr _ _ = return ()
     {-# INLINE shrinkMutableArr #-}
 
-    sameMutableArr (SmallMutableArray smarr1#) (SmallMutableArray smarr2#) =
-        isTrue# (sameSmallMutableArray# smarr1# smarr2#)
+    sameMutableArr (SmallMutableArray smarr1#) (SmallMutableArray smarr2#) = isTrue#
+#if HAVE_SMALL_ARRAY
+        (sameSmallMutableArray# smarr1# smarr2#)
+#else
+        (sameMutableArray# smarr1# smarr2#)
+#endif
     {-# INLINE sameMutableArr #-}
+
     sizeofArr = sizeofSmallArray
     {-# INLINE sizeofArr #-}
     sizeofMutableArr = return . sizeofSmallMutableArray
     {-# INLINE sizeofMutableArr #-}
 
-    sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue# (
-        sameSmallMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
-    {-# INLINE sameArr #-}
+    sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue#
+#if HAVE_SMALL_ARRAY
+        (sameSmallMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
+#else
+        (sameMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
 #endif
+    {-# INLINE sameArr #-}
 
 instance Prim a => Arr MutablePrimArray PrimArray a where
     newArr = newPrimArray

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -11,7 +11,7 @@
 
 {-|
 Module      : Data.Array
-Description : Fast boxed and unboxed arrays
+Description : Unified boxed and unboxed arrays
 Copyright   : (c) Winter, 2017
 License     : BSD3
 Maintainer  : libraries@haskell.org, drkoster@qq.com
@@ -22,6 +22,7 @@ Unified unboxed and boxed array operations using functional dependencies.
 
 All operations are NOT bound checked, if you need checked operations please use "Data.Array.Checked".
 It exports exactly same APIs so that you can switch between without pain.
+
 -}
 
 module Data.Primitive.Array.Class (
@@ -57,13 +58,17 @@ import Data.Primitive.SmallArray
 import Data.Primitive.UnliftedArray
 import GHC.ST
 import GHC.Prim
-import GHC.Types (isTrue#)
+import Data.Primitive.Internal.Compat ( isTrue# )
+
+#if (__GLASGOW_HASKELL__ >= 710)
+#define HAVE_SMALL_ARRAY 1
+#endif
 
 -- | Bottom value (@throw ('UndefinedElement' "Data.Array.uninitialized")@)
 -- for initialize new boxed array('Array', 'SmallArray'..).
 --
 uninitialized :: a
-uninitialized = throw (UndefinedElement "Data.Array.uninitialized")
+uninitialized = throw (UndefinedElement "Data.Primitive.Array.Class.uninitialized")
 
 -- | A typeclass to unify box & unboxed, mutable & immutable array operations.
 --
@@ -242,6 +247,7 @@ instance Arr MutableArray Array a where
         sameMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
     {-# INLINE sameArr #-}
 
+#if HAVE_SMALL_ARRAY
 instance Arr SmallMutableArray SmallArray a where
     newArr n = newSmallArray n uninitialized
     {-# INLINE newArr #-}
@@ -324,6 +330,7 @@ instance Arr SmallMutableArray SmallArray a where
     sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue# (
         sameSmallMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
     {-# INLINE sameArr #-}
+#endif
 
 instance Prim a => Arr MutablePrimArray PrimArray a where
     newArr = newPrimArray

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -1,0 +1,479 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+
+{-|
+Module      : Data.Array
+Description : Fast boxed and unboxed arrays
+Copyright   : (c) Winter, 2017
+License     : BSD3
+Maintainer  : libraries@haskell.org, drkoster@qq.com
+Stability   : experimental
+Portability : non-portable
+
+Unified unboxed and boxed array operations using functional dependencies.
+
+All operations are NOT bound checked, if you need checked operations please use "Data.Array.Checked".
+It exports exactly same APIs so that you can switch between without pain.
+-}
+
+module Data.Primitive.Array.Class (
+  -- * Arr typeclass
+    Arr(..)
+  , RealWorld
+  -- * Boxed array type
+  , Array(..)
+  , MutableArray(..)
+  , SmallArray(..)
+  , SmallMutableArray(..)
+  , uninitialized
+  -- * Primitive array type
+  , PrimArray(..)
+  , MutablePrimArray(..)
+  , Prim(..)
+  , newPinnedPrimArray, newAlignedPinnedPrimArray
+  , copyPrimArrayToPtr, copyMutablePrimArrayToPtr, copyMutablePrimArrayFromPtr
+  -- * Unlifted array type
+  , UnliftedArray(..)
+  , MutableUnliftedArray(..)
+  , PrimUnlifted(..)
+  -- * The 'ArrayException' type
+  , ArrayException(..)
+  ) where
+
+import Data.Primitive.Types
+import Control.Monad.Primitive
+import Control.Exception (ArrayException(..), throw)
+import Data.Primitive.PrimArray
+import Data.Primitive.Array
+import Data.Primitive.SmallArray
+import Data.Primitive.UnliftedArray
+import GHC.ST
+import GHC.Prim
+import GHC.Types (isTrue#)
+
+-- | Bottom value (@throw ('UndefinedElement' "Data.Array.uninitialized")@)
+-- for initialize new boxed array('Array', 'SmallArray'..).
+--
+uninitialized :: a
+uninitialized = throw (UndefinedElement "Data.Array.uninitialized")
+
+-- | A typeclass to unify box & unboxed, mutable & immutable array operations.
+--
+-- Most of these functions simply wrap their primitive counterpart, if there's no primitive ones,
+-- we polyfilled using other operations to get the same semantics.
+--
+-- One exception is that 'shrinkMutableArr' only perform closure resizing on 'PrimArray' because
+-- current RTS support only that, 'shrinkMutableArr' will do nothing on other array type.
+--
+-- It's reasonable to trust GHC with specializing & inlining these polymorphric functions.
+-- They are used across this package and perform identical to their monomophric counterpart.
+--
+class Arr (marr :: * -> * -> *) (arr :: * -> * ) a | arr -> marr, marr -> arr where
+
+    -- | Make a new array with given size.
+    --
+    -- For boxed array, all elements are 'uninitialized' which shall not be accessed.
+    -- For primitive array, elements are just random garbage.
+    newArr :: (PrimMonad m, PrimState m ~ s) => Int -> m (marr s a)
+
+    -- | Make a new array and fill it with an initial value.
+    newArrWith :: (PrimMonad m, PrimState m ~ s) => Int -> a -> m (marr s a)
+
+    -- | Index mutable array in a primitive monad.
+    readArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m a
+
+    -- | Write mutable array in a primitive monad.
+    writeArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> a -> m ()
+
+    -- | Fill mutable array with a given value.
+    setArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> a -> m ()
+
+    -- | Index immutable array, which is a pure operation,
+    indexArr :: arr a -> Int -> a
+
+    -- | Index immutable array in a primitive monad, this helps in situations that
+    -- you want your indexing result is not a thunk referencing whole array.
+    indexArrM :: (Monad m) => arr a -> Int -> m a
+
+    -- | Safely freeze mutable array by make a immutable copy of its slice.
+    freezeArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> m (arr a)
+
+    -- | Safely thaw immutable array by make a mutable copy of its slice.
+    thawArr :: (PrimMonad m, PrimState m ~ s) => arr a -> Int -> Int -> m (marr s a)
+
+    -- | In place freeze a mutable array, the original mutable array can not be used
+    -- anymore.
+    unsafeFreezeArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> m (arr a)
+
+    -- | In place thaw a immutable array, the original immutable array can not be used
+    -- anymore.
+    unsafeThawArr :: (PrimMonad m, PrimState m ~ s) => arr a -> m (marr s a)
+
+    -- | Copy a slice of immutable array to mutable array at given offset.
+    copyArr ::  (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> arr a -> Int -> Int -> m ()
+
+    -- | Copy a slice of mutable array to mutable array at given offset.
+    -- The two mutable arrays shall no be the same one.
+    copyMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> marr s a -> Int -> Int -> m ()
+
+    -- | Copy a slice of mutable array to mutable array at given offset.
+    -- The two mutable arrays may be the same one.
+    moveArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> marr s a -> Int -> Int -> m ()
+
+    -- | Create immutable copy.
+    cloneArr :: arr a -> Int -> Int -> arr a
+
+    -- | Create mutable copy.
+    cloneMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> Int -> m (marr s a)
+
+    -- | Resize mutable array to given size.
+    resizeMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m (marr s a)
+
+    -- | Shrink mutable array to given size. This operation only works on primitive arrays.
+    -- For boxed array, this is a no-op, e.g. 'sizeOfMutableArr' will not change.
+    shrinkMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> Int -> m ()
+
+    -- | Is two mutable array are reference equal.
+    sameMutableArr :: marr s a -> marr s a -> Bool
+
+    -- | Size of immutable array.
+    sizeofArr :: arr a -> Int
+
+    -- | Size of mutable array.
+    sizeofMutableArr :: (PrimMonad m, PrimState m ~ s) => marr s a -> m Int
+
+    -- | Is two immutable array are referencing the same one.
+    --
+    -- Note that 'sameArr' 's result may change depending on compiler's optimizations, for example
+    -- @let arr = runST ... in arr `sameArr` arr@ may return false if compiler decides to
+    -- inline it.
+    --
+    -- See https://ghc.haskell.org/trac/ghc/ticket/13908 for more background.
+    --
+    sameArr :: arr a -> arr a -> Bool
+
+instance Arr MutableArray Array a where
+    newArr n = newArray n uninitialized
+    {-# INLINE newArr #-}
+    newArrWith = newArray
+    {-# INLINE newArrWith #-}
+    readArr = readArray
+    {-# INLINE readArr #-}
+    writeArr = writeArray
+    {-# INLINE writeArr #-}
+    setArr marr s l x = go s
+      where
+        !sl = s + l
+        go !i | i >= sl = return ()
+              | otherwise = writeArray marr i x >> go (i+1)
+    {-# INLINE setArr #-}
+    indexArr = indexArray
+    {-# INLINE indexArr #-}
+    indexArrM = indexArrayM
+    {-# INLINE indexArrM #-}
+    freezeArr = freezeArray
+    {-# INLINE freezeArr #-}
+    thawArr = thawArray
+    {-# INLINE thawArr #-}
+    unsafeFreezeArr = unsafeFreezeArray
+    {-# INLINE unsafeFreezeArr #-}
+    unsafeThawArr = unsafeThawArray
+    {-# INLINE unsafeThawArr #-}
+
+    copyArr = copyArray
+    {-# INLINE copyArr #-}
+    copyMutableArr = copyMutableArray
+    {-# INLINE copyMutableArr #-}
+
+    moveArr marr1 s1 marr2 s2 l
+        | l <= 0 = return ()
+        | sameMutableArray marr1 marr2 =
+            case compare s1 s2 of
+                LT ->
+                    let !d = s2 - s1
+                        !s2l = s2 + l
+                        go !i | i >= s2l = return ()
+                              | otherwise = do x <- readArray marr2 i
+                                               writeArray marr1 (i-d) x
+                                               go (i+1)
+                    in go s2
+
+                EQ -> return ()
+
+                GT ->
+                    let !d = s1 - s2
+                        go !i | i < s2 = return ()
+                              | otherwise = do x <- readArray marr2 i
+                                               writeArray marr1 (i+d) x
+                                               go (i-1)
+                    in go (s2+l-1)
+        | otherwise = copyMutableArray marr1 s1 marr2 s2 l
+    {-# INLINE moveArr #-}
+
+    cloneArr = cloneArray
+    {-# INLINE cloneArr #-}
+    cloneMutableArr = cloneMutableArray
+    {-# INLINE cloneMutableArr #-}
+
+    resizeMutableArr marr n = do
+        marr' <- newArray n uninitialized
+        copyMutableArray marr' 0 marr 0 (sizeofMutableArray marr)
+        return marr'
+    {-# INLINE resizeMutableArr #-}
+    shrinkMutableArr _ _ = return ()
+    {-# INLINE shrinkMutableArr #-}
+
+    sameMutableArr = sameMutableArray
+    {-# INLINE sameMutableArr #-}
+    sizeofArr = sizeofArray
+    {-# INLINE sizeofArr #-}
+    sizeofMutableArr = return . sizeofMutableArray
+    {-# INLINE sizeofMutableArr #-}
+
+    sameArr (Array arr1#) (Array arr2#) = isTrue# (
+        sameMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
+    {-# INLINE sameArr #-}
+
+instance Arr SmallMutableArray SmallArray a where
+    newArr n = newSmallArray n uninitialized
+    {-# INLINE newArr #-}
+    newArrWith = newSmallArray
+    {-# INLINE newArrWith #-}
+    readArr = readSmallArray
+    {-# INLINE readArr #-}
+    writeArr = writeSmallArray
+    {-# INLINE writeArr #-}
+    setArr marr s l x = go s
+      where
+        !sl = s + l
+        go !i | i >= sl = return ()
+              | otherwise = writeSmallArray marr i x >> go (i+1)
+    {-# INLINE setArr #-}
+    indexArr = indexSmallArray
+    {-# INLINE indexArr #-}
+    indexArrM = indexSmallArrayM
+    {-# INLINE indexArrM #-}
+    freezeArr = freezeSmallArray
+    {-# INLINE freezeArr #-}
+    thawArr = thawSmallArray
+    {-# INLINE thawArr #-}
+    unsafeFreezeArr = unsafeFreezeSmallArray
+    {-# INLINE unsafeFreezeArr #-}
+    unsafeThawArr = unsafeThawSmallArray
+    {-# INLINE unsafeThawArr #-}
+
+    copyArr = copySmallArray
+    {-# INLINE copyArr #-}
+    copyMutableArr = copySmallMutableArray
+    {-# INLINE copyMutableArr #-}
+
+    moveArr marr1 s1 marr2 s2 l
+        | l <= 0 = return ()
+        | sameMutableArr marr1 marr2 =
+            case compare s1 s2 of
+                LT ->
+                    let !d = s2 - s1
+                        !s2l = s2 + l
+                        go !i | i >= s2l = return ()
+                              | otherwise = do x <- readSmallArray marr2 i
+                                               writeSmallArray marr1 (i-d) x
+                                               go (i+1)
+                    in go s2
+
+                EQ -> return ()
+
+                GT ->
+                    let !d = s1 - s2
+                        go !i | i < s2 = return ()
+                              | otherwise = do x <- readSmallArray marr2 i
+                                               writeSmallArray marr1 (i+d) x
+                                               go (i-1)
+                    in go (s2+l-1)
+        | otherwise = copySmallMutableArray marr1 s1 marr2 s2 l
+    {-# INLINE moveArr #-}
+
+    cloneArr = cloneSmallArray
+    {-# INLINE cloneArr #-}
+    cloneMutableArr = cloneSmallMutableArray
+    {-# INLINE cloneMutableArr #-}
+
+    resizeMutableArr marr n = do
+        marr' <- newSmallArray n uninitialized
+        copySmallMutableArray marr' 0 marr 0 (sizeofSmallMutableArray marr)
+        return marr'
+    {-# INLINE resizeMutableArr #-}
+    shrinkMutableArr _ _ = return ()
+    {-# INLINE shrinkMutableArr #-}
+
+    sameMutableArr (SmallMutableArray smarr1#) (SmallMutableArray smarr2#) =
+        isTrue# (sameSmallMutableArray# smarr1# smarr2#)
+    {-# INLINE sameMutableArr #-}
+    sizeofArr = sizeofSmallArray
+    {-# INLINE sizeofArr #-}
+    sizeofMutableArr = return . sizeofSmallMutableArray
+    {-# INLINE sizeofMutableArr #-}
+
+    sameArr (SmallArray arr1#) (SmallArray arr2#) = isTrue# (
+        sameSmallMutableArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
+    {-# INLINE sameArr #-}
+
+instance Prim a => Arr MutablePrimArray PrimArray a where
+    newArr = newPrimArray
+    {-# INLINE newArr #-}
+    newArrWith n x = do
+        marr <- newPrimArray n
+        setPrimArray marr 0 n x
+        return marr
+    {-# INLINE newArrWith #-}
+    readArr = readPrimArray
+    {-# INLINE readArr #-}
+    writeArr = writePrimArray
+    {-# INLINE writeArr #-}
+    setArr = setPrimArray
+    {-# INLINE setArr #-}
+    indexArr = indexPrimArray
+    {-# INLINE indexArr #-}
+    indexArrM arr i = return (indexPrimArray arr i)
+    {-# INLINE indexArrM #-}
+    freezeArr marr s l = do
+        marr' <- newPrimArray l
+        copyMutablePrimArray marr' 0 marr s l
+        unsafeFreezePrimArray marr'
+    {-# INLINE freezeArr #-}
+    thawArr arr s l = do
+        marr' <- newPrimArray l
+        copyPrimArray marr' 0 arr s l
+        return marr'
+    {-# INLINE thawArr #-}
+    unsafeFreezeArr = unsafeFreezePrimArray
+    {-# INLINE unsafeFreezeArr #-}
+    unsafeThawArr = unsafeThawPrimArray
+    {-# INLINE unsafeThawArr #-}
+
+    copyArr = copyPrimArray
+    {-# INLINE copyArr #-}
+    copyMutableArr = copyMutablePrimArray
+    {-# INLINE copyMutableArr #-}
+
+    moveArr = movePrimArray
+    {-# INLINE moveArr #-}
+
+    cloneArr arr s l = runST (do
+            marr <- newPrimArray l
+            copyPrimArray marr 0 arr s l
+            unsafeFreezePrimArray marr
+        )
+    {-# INLINE cloneArr #-}
+    cloneMutableArr marr s l = do
+        marr' <- newPrimArray l
+        copyMutablePrimArray marr' 0 marr s l
+        return marr'
+    {-# INLINE cloneMutableArr #-}
+
+    resizeMutableArr = resizeMutablePrimArray
+    {-# INLINE resizeMutableArr #-}
+    shrinkMutableArr = shrinkMutablePrimArray
+    {-# INLINE shrinkMutableArr #-}
+
+    sameMutableArr = sameMutablePrimArray
+    {-# INLINE sameMutableArr #-}
+    sizeofArr = sizeofPrimArray
+    {-# INLINE sizeofArr #-}
+    sizeofMutableArr = sizeofMutablePrimArray
+    {-# INLINE sizeofMutableArr #-}
+
+    sameArr = samePrimArray
+    {-# INLINE sameArr #-}
+
+instance PrimUnlifted a => Arr MutableUnliftedArray UnliftedArray a where
+    newArr = unsafeNewUnliftedArray
+    {-# INLINE newArr #-}
+    newArrWith = newUnliftedArray
+    {-# INLINE newArrWith #-}
+    readArr = readUnliftedArray
+    {-# INLINE readArr #-}
+    writeArr = writeUnliftedArray
+    {-# INLINE writeArr #-}
+    setArr marr s l x = go s
+      where
+        !sl = s + l
+        go !i | i >= sl = return ()
+              | otherwise = writeUnliftedArray marr i x >> go (i+1)
+    {-# INLINE setArr #-}
+    indexArr = indexUnliftedArray
+    {-# INLINE indexArr #-}
+    indexArrM = indexUnliftedArrayM
+    {-# INLINE indexArrM #-}
+    freezeArr = freezeUnliftedArray
+    {-# INLINE freezeArr #-}
+    thawArr = thawUnliftedArray
+    {-# INLINE thawArr #-}
+    unsafeFreezeArr = unsafeFreezeUnliftedArray
+    {-# INLINE unsafeFreezeArr #-}
+    unsafeThawArr (UnliftedArray arr#) = primitive ( \ s0# ->
+            let (# s1#, marr# #) = unsafeThawArray# (unsafeCoerce# arr#) s0#  -- ArrayArray# and Array# use the same representation
+            in (# s1#, MutableUnliftedArray (unsafeCoerce# marr#) #)          -- so this works
+        )
+    {-# INLINE unsafeThawArr #-}
+
+    copyArr = copyUnliftedArray
+    {-# INLINE copyArr #-}
+    copyMutableArr = copyMutableUnliftedArray
+    {-# INLINE copyMutableArr #-}
+
+    moveArr marr1 s1 marr2 s2 l
+        | l <= 0 = return ()
+        | sameMutableUnliftedArray marr1 marr2 =
+            case compare s1 s2 of
+                LT ->
+                    let !d = s2 - s1
+                        !s2l = s2 + l
+                        go !i | i >= s2l = return ()
+                              | otherwise = do x <- readUnliftedArray marr2 i
+                                               writeUnliftedArray marr1 (i-d) x
+                                               go (i+1)
+                    in go s2
+
+                EQ -> return ()
+
+                GT ->
+                    let !d = s1 - s2
+                        go !i | i < s2 = return ()
+                              | otherwise = do x <- readUnliftedArray marr2 i
+                                               writeUnliftedArray marr1 (i+d) x
+                                               go (i-1)
+                    in go (s2+l-1)
+        | otherwise = copyMutableUnliftedArray marr1 s1 marr2 s2 l
+    {-# INLINE moveArr #-}
+
+    cloneArr = cloneUnliftedArray
+    {-# INLINE cloneArr #-}
+    cloneMutableArr = cloneMutableUnliftedArray
+    {-# INLINE cloneMutableArr #-}
+
+    resizeMutableArr marr n = do
+        marr' <- newUnliftedArray n uninitialized
+        copyMutableUnliftedArray marr' 0 marr 0 (sizeofMutableUnliftedArray marr)
+        return marr'
+    {-# INLINE resizeMutableArr #-}
+    shrinkMutableArr _ _ = return ()
+    {-# INLINE shrinkMutableArr #-}
+
+    sameMutableArr = sameMutableUnliftedArray
+    {-# INLINE sameMutableArr #-}
+    sizeofArr = sizeofUnliftedArray
+    {-# INLINE sizeofArr #-}
+    sizeofMutableArr = return . sizeofMutableUnliftedArray
+    {-# INLINE sizeofMutableArr #-}
+
+    sameArr (UnliftedArray arr1#) (UnliftedArray arr2#) = isTrue# (
+        sameMutableArrayArray# (unsafeCoerce# arr1#) (unsafeCoerce# arr2#))
+    {-# INLINE sameArr #-}

--- a/Data/Primitive/Array/Class.hs
+++ b/Data/Primitive/Array/Class.hs
@@ -73,7 +73,7 @@ uninitialized = throw (UndefinedElement "Data.Primitive.Array.Class.uninitialize
 -- | A typeclass to unify box & unboxed, mutable & immutable array operations.
 --
 -- Most of these functions simply wrap their primitive counterpart. If there are no primitive ones,
--- the method is polyfilled using other operations to get the same semantics.
+-- the method is emulated using other operations to get the same semantics.
 --
 class Arr (marr :: * -> * -> *) (arr :: * -> * ) a | arr -> marr, marr -> arr where
 
@@ -82,7 +82,7 @@ class Arr (marr :: * -> * -> *) (arr :: * -> * ) a | arr -> marr, marr -> arr wh
     -- It's not safe to access uninitialized element.
     -- For boxed arrays, all elements are @uninitialized@, a thunk that throws
     -- an error if it is forced. For primitive array, elements are uninitialized memory.
-    -- For unlifted array , elements are the refrerence to itself.
+    -- For unlifted array , elements are the reference to itself.
     --
     newArr :: (PrimMonad m, PrimState m ~ s) => Int -> m (marr s a)
 

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -338,7 +338,7 @@ resizeMutableByteArray mba@(MutableByteArray mba#) sz@(I# i#) = do
        )
 #else
     mba' <- newByteArray sz
-    copyMutableByteArray mba' sz mba 0 (sizeofMutableByteArray mba)
+    copyMutableByteArray mba' 0 mba 0 (min sz (sizeofMutableByteArray mba))
     return mba'
 #endif
 {-# INLINE resizeMutableByteArray #-}

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -465,14 +465,23 @@ sameByteArray (ByteArray ba1#) (ByteArray ba2#) =
 isByteArrayPinned :: ByteArray -> Bool
 {-# INLINE isByteArrayPinned #-}
 isByteArrayPinned (ByteArray ba#) =
+#if MIN_VERSION_ghc_prim(0,5,1)
+    isTrue# (isByteArrayPinned# ba#)
+#else
     c_is_byte_array_pinned ba# > 0
+#endif
+
 
 -- | Check if a mutable byte array is pinned.
 --
 isMutableByteArrayPinned :: MutableByteArray s -> Bool
 {-# INLINE isMutableByteArrayPinned #-}
 isMutableByteArrayPinned (MutableByteArray mba#) =
+#if MIN_VERSION_ghc_prim(0,5,1)
+    isTrue# (isMutableByteArrayPinned# mba#)
+#else
     c_is_mutable_byte_array_pinned mba# > 0
+#endif
 
 foreign import ccall unsafe "hsprimitive_is_byte_array_pinned"
     c_is_byte_array_pinned :: ByteArray# -> CInt

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -75,8 +75,8 @@ instance Ord ByteArray where
     paA@(ByteArray baA#) `compare` paB@(ByteArray baB#)
         | sameByteArray paA paB = EQ
         | otherwise =
-            let sizA = sizeofByteArray paA
-                sizB = sizeofByteArray paB
+            let !sizA = sizeofByteArray paA
+                !sizB = sizeofByteArray paB
                 r = c_memcmp baA# baB# (fromIntegral $ min sizA sizB)
             in case r `compare` 0 of
                 EQ  -> sizA `compare` sizB

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, MagicHash, UnboxedTuples, UnliftedFFITypes, DeriveDataTypeable #-}
+{-# LANGUAGE BangPatterns #-}
 
 -- |
 -- Module      : Data.Primitive.ByteArray
@@ -332,7 +333,7 @@ resizeMutableByteArray :: PrimMonad m
 resizeMutableByteArray mba@(MutableByteArray mba#) sz@(I# i#) = do
 #if __GLASGOW_HASKELL__ >= 710
     primitive (\ s# ->
-            let (# s'#, mba'# #) = resizeMutableByteArray# mba# i# s#
+            let !(# s'#, mba'# #) = resizeMutableByteArray# mba# i# s#
             in (# s'#, (MutableByteArray mba'#) #)
        )
 #else

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -347,7 +347,9 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memcpy"
   memcpy_ba :: MutableByteArray# s -> CInt
             -> ByteArray# -> CInt
             -> CSize -> IO ()
+#endif
 
+#if __GLASGOW_HASKELL__ < 780
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memcpy"
   memcpy_mba_to_addr :: Addr# -> CInt
                      -> MutableByteArray# s -> CInt

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -315,7 +315,7 @@ resizeMutableByteArray mba@(MutableByteArray mba#) sz@(I# i#) = do
        )
 #else
     mba' <- newByteArray sz
-    copyMutableByteArray mba' sz mba 0 (sizeofByteArray mba)
+    copyMutableByteArray mba' sz mba 0 (sizeofMutableByteArray mba)
     return mba'
 #endif
 {-# INLINE resizeMutableByteArray #-}

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -218,8 +218,8 @@ copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff@(I# soff#) sz@(I# n#) =
 #if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyByteArrayToAddr# src# soff# dst# n#)
 #else
-  = unsafePrimToPrim
-  $ memcpy_ba_to_addr dst# 0 src# (fromIntegral soff) (fromIntegral sz)
+    unsafePrimToPrim
+        $ memcpy_ba_to_addr dst# 0 src# (fromIntegral soff) (fromIntegral sz)
 #endif
 
 -- | Copy a slice of an mutable primitive array to an address.
@@ -236,8 +236,8 @@ copyMutableByteArrayToAddr (Addr dst#) (MutableByteArray src#) soff@(I# soff#) s
 #if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyMutableByteArrayToAddr# src# soff# dst# n#)
 #else
-  = unsafePrimToPrim
-  $ memcpy_mba_to_addr dst# 0 src# (fromIntegral soff) (fromIntegral sz)
+    unsafePrimToPrim
+        $ memcpy_mba_to_addr dst# 0 src# (fromIntegral soff) (fromIntegral sz)
 #endif
 
 -- | Copy a slice of an mutable primitive array from an address.
@@ -254,8 +254,8 @@ copyMutableByteArrayFromAddr (MutableByteArray dst#) doff@(I# doff#) (Addr src#)
 #if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyAddrToByteArray# src# dst# doff# n#)
 #else
-  = unsafePrimToPrim
-  $ memcpy_mba_from_addr dst# (fromIntegral doff) src# 0 (fromIntegral sz)
+    unsafePrimToPrim
+        $ memcpy_mba_from_addr dst# (fromIntegral doff) src# 0 (fromIntegral sz)
 #endif
 
 -- | Copy a slice of a mutable byte array into another, potentially

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -215,7 +215,7 @@ copyByteArrayToAddr :: PrimMonad m
               -> m ()
 {-# INLINE copyByteArrayToAddr #-}
 copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff@(I# soff#) sz@(I# n#) =
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyByteArrayToAddr# src# soff# dst# n#)
 #else
   = unsafePrimToPrim
@@ -233,7 +233,7 @@ copyMutableByteArrayToAddr :: PrimMonad m
               -> m ()
 {-# INLINE copyMutableByteArrayToAddr #-}
 copyMutableByteArrayToAddr (Addr dst#) (MutableByteArray src#) soff@(I# soff#) sz@(I# n#) =
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyMutableByteArrayToAddr# src# soff# dst# n#)
 #else
   = unsafePrimToPrim
@@ -251,7 +251,7 @@ copyMutableByteArrayFromAddr :: PrimMonad m
               -> m ()
 {-# INLINE copyMutableByteArrayFromAddr #-}
 copyMutableByteArrayFromAddr (MutableByteArray dst#) doff@(I# doff#) (Addr src#) sz@(I# n#) =
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 780
     primitive_ (copyAddrToByteArray# src# dst# doff# n#)
 #else
   = unsafePrimToPrim
@@ -315,7 +315,7 @@ resizeMutableByteArray mba@(MutableByteArray mba#) sz@(I# i#) = do
        )
 #else
     mba' <- newByteArray sz
-    copyMutableByteArray mba' sz mba 0 (sizeOfByteArray mba)
+    copyMutableByteArray mba' sz mba 0 (sizeofByteArray mba)
     return mba'
 #endif
 {-# INLINE resizeMutableByteArray #-}

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -105,14 +105,14 @@ newtype MutablePrimArray s a = MutablePrimArray (MutableByteArray s)
 -- | Create a new mutable primitive array of the specified size.
 newPrimArray :: forall m a . (PrimMonad m, Prim a) => Int -> m (MutablePrimArray (PrimState m) a)
 {-# INLINE newPrimArray #-}
-newPrimArray n = MutablePrimArray `fmap` newByteArray (n*siz)
+newPrimArray n = MutablePrimArray `liftM` newByteArray (n*siz)
   where siz = sizeOf (undefined :: a)
 
 -- | Create a /pinned/ byte array of the specified size and respect the primitive type's
 -- alignment. The garbage collector is guaranteed not to move it.
 newPinnedPrimArray :: forall m a. (PrimMonad m, Prim a) => Int -> m (MutablePrimArray (PrimState m) a)
 {-# INLINE newPinnedPrimArray #-}
-newPinnedPrimArray n = MutablePrimArray `fmap` newAlignedPinnedByteArray (n*siz) align
+newPinnedPrimArray n = MutablePrimArray `liftM` newAlignedPinnedByteArray (n*siz) align
   where siz = sizeOf (undefined :: a)
         align = alignment (undefined :: a)
 
@@ -121,7 +121,7 @@ newPinnedPrimArray n = MutablePrimArray `fmap` newAlignedPinnedByteArray (n*siz)
 newAlignedPinnedPrimArray
   :: forall m a. (PrimMonad m, Prim a) => Int -> Int -> m (MutablePrimArray (PrimState m) a)
 {-# INLINE newAlignedPinnedPrimArray #-}
-newAlignedPinnedPrimArray n align = MutablePrimArray `fmap` newAlignedPinnedByteArray (n*siz) align
+newAlignedPinnedPrimArray n align = MutablePrimArray `liftM` newAlignedPinnedByteArray (n*siz) align
   where siz = sizeOf (undefined :: a)
 
 -- | Yield a pointer to the array's data.
@@ -181,14 +181,14 @@ sameMutablePrimArray (MutablePrimArray mbaA) (MutablePrimArray mbaB) = sameMutab
 unsafeFreezePrimArray
   :: (PrimMonad m) => MutablePrimArray (PrimState m) a -> m (PrimArray a)
 {-# INLINE unsafeFreezePrimArray #-}
-unsafeFreezePrimArray (MutablePrimArray mba) = PrimArray `fmap` unsafeFreezeByteArray mba
+unsafeFreezePrimArray (MutablePrimArray mba) = PrimArray `liftM` unsafeFreezeByteArray mba
 
 -- | Convert an immutable primitive array to a mutable one without copying. The
 -- original array should not be used after the conversion.
 unsafeThawPrimArray
   :: (PrimMonad m) => PrimArray a -> m (MutablePrimArray (PrimState m) a)
 {-# INLINE unsafeThawPrimArray #-}
-unsafeThawPrimArray (PrimArray ba) = MutablePrimArray `fmap` unsafeThawByteArray ba
+unsafeThawPrimArray (PrimArray ba) = MutablePrimArray `liftM` unsafeThawByteArray ba
 
 -- | Size of the primitive array.
 sizeofPrimArray :: forall a . (Prim a) => PrimArray a -> Int
@@ -204,7 +204,7 @@ sizeofMutablePrimArray (MutablePrimArray mba) =
     let getSizeofMutableByteArray (MutableByteArray mba#) = primitive (\ s# ->
             let (# s'#, l# #) = getSizeofMutableByteArray# mba# s#
             in (# s'#, (I# l#) #))
-    in (`quot` siz) `fmap` getSizeofMutableByteArray mba
+    in (`quot` siz) `liftM` getSizeofMutableByteArray mba
 #else
     return (sizeofMutableByteArray mba `quot` siz)
 #endif
@@ -336,7 +336,7 @@ resizeMutablePrimArray :: forall m a. (PrimMonad m, Prim a)
                        -> Int
                        -> m (MutablePrimArray (PrimState m) a)
 resizeMutablePrimArray (MutablePrimArray mba) sz =
-    MutablePrimArray `fmap` resizeMutableByteArray mba (sz * siz)
+    MutablePrimArray `liftM` resizeMutableByteArray mba (sz * siz)
   where siz = sizeOf (undefined :: a)
 {-# INLINE resizeMutablePrimArray #-}
 

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -41,7 +41,8 @@ Here is an example of an RGB pixel 'Prim' instance.
     ...
 @
 
-Now you can use 'PrimArray' 'Pixel' with either this module or @Data.Array@/@Data.Vector@.
+Now you can use 'PrimArray Pixel' with either this module or
+"Data.Primitive.Array.Class/Data.Primitive.Array.Checked".
 -}
 
 

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -219,7 +219,7 @@ sizeofMutablePrimArray :: forall m a . (PrimMonad m, Prim a) => MutablePrimArray
 sizeofMutablePrimArray (MutablePrimArray mba) =
 #if MIN_VERSION_ghc_prim(0,5,0)
     let getSizeofMutableByteArray (MutableByteArray mba#) = primitive (\ s# ->
-            let (# s'#, l# #) = getSizeofMutableByteArray# mba# s#
+            let !(# s'#, l# #) = getSizeofMutableByteArray# mba# s#
             in (# s'#, (I# l#) #))
     in (`quot` siz) `liftM` getSizeofMutableByteArray mba
 #else

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -85,6 +85,9 @@ import GHC.Word (Word8)
 import GHC.Prim
 import Data.Primitive.Internal.Compat ( isTrue# )
 
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Monoid (mappend)
+#endif
 
 -- | Primitive array tagged with element type @a@.
 --

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -1,0 +1,427 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE UnliftedFFITypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
+
+{-|
+Module      : Data.Primitive.PrimArray
+Description : Primitive arrays tagged with element type
+Copyright   : (c) Winter, 2017
+License     : BSD3
+
+Maintainer  : drkoster@qq.com, libraries@haskell.org
+Stability   : experimental
+Portability : non-portable
+
+This module provide primitive arrays tagged with element type, all offset, length .. ,etc. is based on
+elemment not byte, and operations are NOT bound checked.
+
+You can define new primitive array by defining 'Prim' instances, but since GHC heap array are word aligned,
+It's not recommand to use 'PrimArray' with a type which alignment is not submultiple of word size. Otherwise
+you have to use 'newAlignedPinnedPrimArray' to make a new array for such a type.
+
+Here is an example of a RGB pixel 'Prim' instance.
+
+@
+  data Pixel = Pixel Word8 Word8 Word8 -- you may want to unpack these
+  instance Prim Pixel where
+    sizeOf# _ = 3#
+    alignment# _ = 1#
+    indexByteArray# ba# i# = Pixel (indexByteArray# ba# i#)
+                                (indexByteArray# ba# (i# +# 1#))
+                                (indexByteArray# ba# (i# +# 2#))
+    ...
+@
+
+Now you can use 'PrimArray Pixel' with either this module or "Data.Array/Data.Vector".
+-}
+
+
+module Data.Primitive.PrimArray (
+  -- * Types
+  PrimArray(..), MutablePrimArray(..),
+
+  -- * Allocation
+  newPrimArray, newPinnedPrimArray, newAlignedPinnedPrimArray,
+
+  -- * Element access
+  readPrimArray, writePrimArray, indexPrimArray,
+
+  -- * Freezing and thawing
+  unsafeFreezePrimArray, unsafeThawPrimArray,
+
+  -- * Block operations
+  copyPrimArray, copyMutablePrimArray, movePrimArray,
+  setPrimArray, resizeMutablePrimArray, shrinkMutablePrimArray,
+  copyPrimArrayToPtr, copyMutablePrimArrayToPtr, copyMutablePrimArrayFromPtr,
+
+  -- * Information
+  sizeofPrimArray, sizeofMutablePrimArray, sameMutablePrimArray,
+  primArrayContents, mutablePrimArrayContents, withPrimArrayContents, withMutablePrimArrayContents,
+  isPrimArrayPinned, isMutablePrimArrayPinned,
+  samePrimArray,
+
+  -- * Prefetch
+  -- | Check <http://hackage.haskell.org/package/ghc-prim-0.3.1.0/docs/GHC-Prim.html#Prefetch> for more information.
+
+  prefetchPrimArray0, prefetchPrimArray1, prefetchPrimArray2, prefetchPrimArray3,
+  prefetchMutablePrimArray0, prefetchMutablePrimArray1, prefetchMutablePrimArray2, prefetchMutablePrimArray3
+
+) where
+
+
+import Control.Monad.Primitive
+import Data.Primitive
+import Data.Typeable
+import Data.Data
+import Foreign.C.Types (CInt(..))
+import GHC.Ptr (Ptr(..))
+import GHC.Types
+import GHC.Prim
+
+
+-- | Primitive array tagged with element type @a@.
+--
+newtype PrimArray a = PrimArray ByteArray
+    deriving (Typeable, Data)
+
+instance (Prim a, Eq a) => Eq (PrimArray a) where
+    paA@(PrimArray (ByteArray baA#)) == paB@(PrimArray (ByteArray baB#)) =
+        samePrimArray paA paB || (
+            let sizA = sizeofPrimArray paA
+                sizB = sizeofPrimArray paB
+            in sizA == sizB && c_memcmp baA# baB# (fromIntegral sizA) == 0)
+
+foreign import ccall unsafe "cstring.h memcmp" c_memcmp :: ByteArray# -> ByteArray# -> CInt -> CInt
+
+-- | Mutable primitive array tagged with element type @a@.
+--
+newtype MutablePrimArray s a = MutablePrimArray (MutableByteArray s)
+    deriving (Typeable, Data)
+
+-- | Create a new mutable primitive array of the specified size.
+newPrimArray :: forall m a . (PrimMonad m, Prim a) => Int -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE newPrimArray #-}
+newPrimArray n = MutablePrimArray `fmap` newByteArray (n*siz)
+  where siz = sizeOf (undefined :: a)
+
+-- | Create a /pinned/ byte array of the specified size and respect the primitive type's
+-- alignment. The garbage collector is guaranteed not to move it.
+newPinnedPrimArray :: forall m a. (PrimMonad m, Prim a) => Int -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE newPinnedPrimArray #-}
+newPinnedPrimArray n = MutablePrimArray `fmap` newAlignedPinnedByteArray (n*siz) align
+  where siz = sizeOf (undefined :: a)
+        align = alignment (undefined :: a)
+
+-- | Create a /pinned/ primitive array of the specified size and respect given
+-- alignment. The garbage collector is guaranteed not to move it.
+newAlignedPinnedPrimArray
+  :: forall m a. (PrimMonad m, Prim a) => Int -> Int -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE newAlignedPinnedPrimArray #-}
+newAlignedPinnedPrimArray n align = MutablePrimArray `fmap` newAlignedPinnedByteArray (n*siz) align
+  where siz = sizeOf (undefined :: a)
+
+-- | Yield a pointer to the array's data.
+-- This operation is only safe on /pinned/ primitive arrays allocated by 'newPinnedPrimArray' or
+-- 'newAlignedPinnedPrimArray', and you have to make sure the 'PrimArray' can outlive the 'Ptr'.
+--
+primArrayContents :: PrimArray a -> Ptr a
+{-# INLINE primArrayContents #-}
+primArrayContents (PrimArray ba) =
+    let !(Addr addr#) = byteArrayContents ba in Ptr addr#
+
+-- | Yield a pointer to the array's data.
+--
+-- This operation is only safe on /pinned/ primitive arrays allocated by 'newPinnedPrimArray' or
+-- 'newAlignedPinnedPrimArray'. and you have to make sure the 'PrimArray' can outlive the 'Ptr'.
+--
+mutablePrimArrayContents :: MutablePrimArray s a -> Ptr a
+{-# INLINE mutablePrimArrayContents #-}
+mutablePrimArrayContents (MutablePrimArray mba) =
+    let !(Addr addr#) = mutableByteArrayContents mba in Ptr addr#
+
+-- | Yield a pointer to the array's data and do computation with it.
+--
+-- This operation is only safe on /pinned/ primitive arrays allocated by 'newPinnedPrimArray' or
+-- 'newAlignedPinnedPrimArray'.
+--
+withPrimArrayContents :: PrimArray a -> (Ptr a -> IO b) -> IO b
+{-# INLINE withPrimArrayContents #-}
+withPrimArrayContents (PrimArray ba) f = do
+    let !(Addr addr#) = byteArrayContents ba
+        ptr = Ptr addr#
+    b <- f ptr
+    touch ba
+    return b
+
+-- | Yield a pointer to the array's data and do computation with it.
+--
+-- This operation is only safe on /pinned/ primitive arrays allocated by 'newPinnedPrimArray' or
+-- 'newAlignedPinnedPrimArray'.
+--
+withMutablePrimArrayContents :: MutablePrimArray RealWorld a -> (Ptr a -> IO b) -> IO b
+{-# INLINE withMutablePrimArrayContents #-}
+withMutablePrimArrayContents (MutablePrimArray mba) f = do
+    let !(Addr addr#) = mutableByteArrayContents mba
+        ptr = Ptr addr#
+    b <- f ptr
+    touch mba
+    return b
+
+-- | Check if the two arrays refer to the same memory block.
+sameMutablePrimArray :: MutablePrimArray s a -> MutablePrimArray s a -> Bool
+{-# INLINE sameMutablePrimArray #-}
+sameMutablePrimArray (MutablePrimArray mbaA) (MutablePrimArray mbaB) = sameMutableByteArray mbaA mbaB
+
+-- | Convert a mutable primitive array to an immutable one without copying. The
+-- array should not be modified after the conversion.
+unsafeFreezePrimArray
+  :: (PrimMonad m) => MutablePrimArray (PrimState m) a -> m (PrimArray a)
+{-# INLINE unsafeFreezePrimArray #-}
+unsafeFreezePrimArray (MutablePrimArray mba) = PrimArray `fmap` unsafeFreezeByteArray mba
+
+-- | Convert an immutable primitive array to a mutable one without copying. The
+-- original array should not be used after the conversion.
+unsafeThawPrimArray
+  :: (PrimMonad m) => PrimArray a -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE unsafeThawPrimArray #-}
+unsafeThawPrimArray (PrimArray ba) = MutablePrimArray `fmap` unsafeThawByteArray ba
+
+-- | Size of the primitive array.
+sizeofPrimArray :: forall a . (Prim a) => PrimArray a -> Int
+{-# INLINE sizeofPrimArray #-}
+sizeofPrimArray (PrimArray ba) = sizeofByteArray ba `quot` siz
+  where siz = sizeOf (undefined :: a)
+
+-- | Size of the mutable primitive array.
+sizeofMutablePrimArray :: forall m a . (PrimMonad m, Prim a) => MutablePrimArray (PrimState m) a -> m Int
+{-# INLINE sizeofMutablePrimArray #-}
+sizeofMutablePrimArray (MutablePrimArray mba) =
+#if MIN_VERSION_ghc_prim(0,5,0)
+    let getSizeofMutableByteArray (MutableByteArray mba#) = primitive (\ s# ->
+            let (# s'#, l# #) = getSizeofMutableByteArray# mba# s#
+            in (# s'#, (I# l#) #))
+    in (`quot` siz) `fmap` getSizeofMutableByteArray mba
+#else
+    return (sizeofMutableByteArray mba `quot` siz)
+#endif
+  where
+    siz = sizeOf (undefined :: a)
+
+-- | Read a primitive value from the primitive array. The offset is given in
+-- elements of type @a@.
+indexPrimArray :: Prim a => PrimArray a -> Int -> a
+{-# INLINE indexPrimArray #-}
+indexPrimArray (PrimArray ba) = indexByteArray ba
+
+-- | Read a primitive value from the primitive array. The offset is given in
+-- elements of type @a@.
+readPrimArray
+  :: forall m a. (PrimMonad m, Prim a) => MutablePrimArray (PrimState m) a -> Int -> m a
+{-# INLINE readPrimArray #-}
+readPrimArray (MutablePrimArray mba) = readByteArray mba
+
+-- | Write a primitive value to the primitive array. The offset is given in
+-- elements of type @a@.
+writePrimArray
+  :: forall m a. (PrimMonad m, Prim a) => MutablePrimArray (PrimState m) a -> Int -> a -> m ()
+{-# INLINE writePrimArray #-}
+writePrimArray (MutablePrimArray mba) = writeByteArray mba
+
+-- | Copy a slice of an immutable primitive array to a mutable primitive array.
+-- The offset and length are given in elements of type @a@.
+copyPrimArray :: forall m a. (PrimMonad m, Prim a)
+              => MutablePrimArray (PrimState m) a -- ^ destination array
+              -> Int                              -- ^ offset into destination array
+              -> PrimArray a                      -- ^ source array
+              -> Int                              -- ^ offset into source array
+              -> Int                              -- ^ number of prims to copy
+              -> m ()
+{-# INLINE copyPrimArray #-}
+copyPrimArray (MutablePrimArray dst) doff (PrimArray src) soff n =
+    copyByteArray dst (doff*siz) src (soff*siz) (n*siz)
+  where siz = sizeOf (undefined :: a)
+
+-- | Copy a slice of an immutable primitive array to an address.
+-- The offset and length are given in elements of type @a@.
+copyPrimArrayToPtr :: forall m a. (PrimMonad m, Prim a)
+              => Ptr a                            -- ^ destination pointer
+              -> PrimArray a                      -- ^ source array
+              -> Int                              -- ^ offset into source array
+              -> Int                              -- ^ number of prims to copy
+              -> m ()
+{-# INLINE copyPrimArrayToPtr #-}
+copyPrimArrayToPtr (Ptr addr#) (PrimArray (ByteArray ba#)) (I# soff#) (I# n#) =
+    primitive (\ s# ->
+        let s'# = copyByteArrayToAddr# ba# (soff# *# siz#) addr# (n# *# siz#) s#
+        in (# s'#, () #))
+  where siz# = sizeOf# (undefined :: a)
+
+-- | Copy a slice of an mutable primitive array to an address.
+-- The offset and length are given in elements of type @a@.
+--
+copyMutablePrimArrayToPtr :: forall m a. (PrimMonad m, Prim a)
+              => Ptr a                            -- ^ destination pointer
+              -> MutablePrimArray (PrimState m) a -- ^ source array
+              -> Int                              -- ^ offset into source array
+              -> Int                              -- ^ number of prims to copy
+              -> m ()
+{-# INLINE copyMutablePrimArrayToPtr #-}
+copyMutablePrimArrayToPtr (Ptr addr#) (MutablePrimArray (MutableByteArray mba#)) (I# soff#) (I# n#) =
+    primitive (\ s# ->
+        let s'# = copyMutableByteArrayToAddr# mba# (soff# *# siz#) addr# (n# *# siz#) s#
+        in (# s'#, () #))
+  where siz# = sizeOf# (undefined :: a)
+
+-- | Copy a slice of an mutable primitive array from an address.
+-- The offset and length are given in elements of type @a@.
+--
+copyMutablePrimArrayFromPtr :: forall m a. (PrimMonad m, Prim a)
+              => MutablePrimArray (PrimState m) a -- ^ destination array
+              -> Int                              -- ^ offset into destination array
+              -> Ptr a                            -- ^ source pointer
+              -> Int                              -- ^ number of prims to copy
+              -> m ()
+{-# INLINE copyMutablePrimArrayFromPtr #-}
+copyMutablePrimArrayFromPtr (MutablePrimArray (MutableByteArray mba#)) (I# doff#) (Ptr addr#) (I# n#) =
+    primitive (\ s# ->
+        let s'# = copyAddrToByteArray# addr# mba# (doff# *# siz#) (n# *# siz#) s#
+        in (# s'#, () #))
+  where siz# = sizeOf# (undefined :: a)
+
+-- | Copy a slice of a mutable primitive array into another array. The two slices
+-- may not overlap.
+-- The offset and length are given in elements of type @a@.
+copyMutablePrimArray :: forall m a. (PrimMonad m, Prim a)
+                     => MutablePrimArray (PrimState m) a -- ^ destination array
+                     -> Int                              -- ^ offset into destination array
+                     -> MutablePrimArray (PrimState m) a -- ^ source array
+                     -> Int                              -- ^ offset into source array
+                     -> Int                              -- ^ number of prims to copy
+                     -> m ()
+{-# INLINE copyMutablePrimArray #-}
+copyMutablePrimArray (MutablePrimArray dst) doff (MutablePrimArray src) soff n =
+    copyMutableByteArray dst (doff*siz) src (soff*siz) (n*siz)
+  where siz = sizeOf (undefined :: a)
+
+-- | Copy a slice of a mutable primitive array into another, potentially
+-- overlapping array.
+-- The offset and length are given in elements of type @a@.
+movePrimArray :: forall m a. (PrimMonad m, Prim a)
+              => MutablePrimArray (PrimState m) a -- ^ destination array
+              -> Int                              -- ^ offset into destination array
+              -> MutablePrimArray (PrimState m) a -- ^ source array
+              -> Int                              -- ^ offset into source array
+              -> Int                              -- ^ number of prims to copy
+              -> m ()
+{-# INLINE movePrimArray #-}
+movePrimArray (MutablePrimArray dst) doff (MutablePrimArray src) soff n =
+    moveByteArray dst (doff*siz) src (soff*siz) (n*siz)
+  where siz = sizeOf (undefined :: a)
+
+-- | Fill a slice of a mutable primitive array with a value.
+-- The offset and length are given in elements of type @a@.
+setPrimArray :: forall m a. (PrimMonad m, Prim a)
+             => MutablePrimArray (PrimState m) a -- ^ array to fill
+             -> Int                              -- ^ offset into array
+             -> Int                              -- ^ number of values to fill
+             -> a                                -- ^ value to fill with
+             -> m ()
+{-# INLINE setPrimArray #-}
+setPrimArray (MutablePrimArray mba) = setByteArray mba
+
+-- | Resize a primitive array using 'resizeMutableByteArray#'.
+--
+-- To avoid undefined behaviour, the original 'MutablePrimArray' shall not be accessed anymore.
+--
+resizeMutablePrimArray :: forall m a. (PrimMonad m, Prim a)
+                       => MutablePrimArray (PrimState m) a
+                       -> Int
+                       -> m (MutablePrimArray (PrimState m) a)
+resizeMutablePrimArray (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive (\ s# ->
+            let (# s'#, mba'# #) = resizeMutableByteArray# mba# (i# *# siz#) s#
+            in (# s'#, MutablePrimArray (MutableByteArray mba'#) #)
+       )
+  where siz# = sizeOf# (undefined :: a)
+{-# INLINE resizeMutablePrimArray #-}
+
+-- | Shrink a primitive array using 'shrinkMutableByteArray#'.
+--
+-- The new size argument must be less than or equal to the current size, but it's not checked.
+--
+shrinkMutablePrimArray :: forall m a. (Prim a, PrimMonad m)
+                       => MutablePrimArray (PrimState m) a
+                       -> Int
+                       -> m ()
+shrinkMutablePrimArray (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive (\ s# ->
+            let s'# = shrinkMutableByteArray# mba# (i# *# siz#) s#
+            in (# s'#, () #)
+       )
+  where siz# = sizeOf# (undefined :: a)
+{-# INLINE shrinkMutablePrimArray #-}
+
+-- | Check if the two immutable arrays refer to the same memory block.
+samePrimArray :: PrimArray a -> PrimArray a -> Bool
+{-# INLINE samePrimArray #-}
+samePrimArray (PrimArray (ByteArray ba1#)) (PrimArray (ByteArray ba2#)) =
+    isTrue# (sameMutableByteArray# (unsafeCoerce# ba1#) (unsafeCoerce# ba2#))
+
+--------------------------------------------------------------------------------
+
+prefetchPrimArray0, prefetchPrimArray1, prefetchPrimArray2, prefetchPrimArray3
+    :: PrimMonad m => PrimArray a -> Int -> m ()
+{-# INLINE prefetchPrimArray0 #-}
+{-# INLINE prefetchPrimArray1 #-}
+{-# INLINE prefetchPrimArray2 #-}
+{-# INLINE prefetchPrimArray3 #-}
+prefetchPrimArray0 (PrimArray (ByteArray ba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchByteArray0# ba# i# s# in (# s'#, () #))
+prefetchPrimArray1 (PrimArray (ByteArray ba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchByteArray1# ba# i# s# in (# s'#, () #))
+prefetchPrimArray2 (PrimArray (ByteArray ba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchByteArray2# ba# i# s# in (# s'#, () #))
+prefetchPrimArray3 (PrimArray (ByteArray ba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchByteArray3# ba# i# s# in (# s'#, () #))
+
+
+prefetchMutablePrimArray0, prefetchMutablePrimArray1, prefetchMutablePrimArray2, prefetchMutablePrimArray3
+    :: PrimMonad m => MutablePrimArray (PrimState m) a -> Int -> m ()
+{-# INLINE prefetchMutablePrimArray0 #-}
+{-# INLINE prefetchMutablePrimArray1 #-}
+{-# INLINE prefetchMutablePrimArray2 #-}
+{-# INLINE prefetchMutablePrimArray3 #-}
+prefetchMutablePrimArray0 (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchMutableByteArray0# mba# i# s# in (# s'#, () #))
+prefetchMutablePrimArray1 (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchMutableByteArray1# mba# i# s# in (# s'#, () #))
+prefetchMutablePrimArray2 (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchMutableByteArray2# mba# i# s# in (# s'#, () #))
+prefetchMutablePrimArray3 (MutablePrimArray (MutableByteArray mba#)) (I# i#) =
+    primitive ( \ s# -> let s'# = prefetchMutableByteArray3# mba# i# s# in (# s'#, () #))
+
+--------------------------------------------------------------------------------
+--
+-- | Check if a primitive array is pinned.
+--
+isPrimArrayPinned :: PrimArray a -> Bool
+{-# INLINE isPrimArrayPinned #-}
+isPrimArrayPinned (PrimArray (ByteArray ba#)) =
+    c_is_byte_array_pinned ba# > 0
+
+-- | Check if a mutable primitive array is pinned.
+--
+isMutablePrimArrayPinned :: MutablePrimArray s a -> Bool
+{-# INLINE isMutablePrimArrayPinned #-}
+isMutablePrimArrayPinned (MutablePrimArray (MutableByteArray mba#)) =
+    c_is_mutable_byte_array_pinned mba# > 0
+
+foreign import ccall unsafe "hsprimitive_is_byte_array_pinned"
+    c_is_byte_array_pinned :: ByteArray# -> CInt
+
+foreign import ccall unsafe "hsprimitive_is_byte_array_pinned"
+    c_is_mutable_byte_array_pinned :: MutableByteArray# s -> CInt

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -99,15 +99,13 @@ instance {-# OVERLAPPABLE #-} (Prim a, Ord a) => Ord (PrimArray a) where
     {-# INLINE compare #-}
     paA `compare` paB
         | paA `samePrimArray` paB = EQ
-        | otherwise = go 0 0
+        | otherwise = go 0
       where
         !endA = sizeofPrimArray paA
         !endB = sizeofPrimArray paB
-        go !i !j | i >= endA  = endA `compare` endB
-                 | j >= endB  = endA `compare` endB
-                 | otherwise = let o = indexPrimArray paA i `compare` indexPrimArray paB j
-                               in case o of EQ -> go (i+1) (j+1)
-                                            x  -> x
+        end = endA `min` endB
+        go !i | i >= end  = endA `compare` endB
+              | otherwise = indexPrimArray paA i `compare` indexPrimArray paB i `mappend` go (i+1)
 instance {-# OVERLAPPING #-} Ord (PrimArray Word8) where
     {-# INLINE compare #-}
     (PrimArray baA) `compare` (PrimArray baB) = baA `compare` baB

--- a/Data/Primitive/UnliftedArray.hs
+++ b/Data/Primitive/UnliftedArray.hs
@@ -67,6 +67,10 @@ import Data.Typeable
 
 import GHC.Prim
 import GHC.Base (Int(..))
+import GHC.MVar (MVar(..))
+import GHC.IORef (IORef(..))
+import GHC.STRef (STRef(..))
+import GHC.Conc.Sync (TVar(..))
 
 import Control.Monad.Primitive
 
@@ -136,6 +140,22 @@ instance PrimUnlifted (SA.SmallMutableArray s a) where
 instance PrimUnlifted (MV.MutVar s a) where
   toArrayArray# (MV.MutVar mv#) = unsafeCoerce# mv#
   fromArrayArray# aa# = MV.MutVar (unsafeCoerce# aa#)
+
+instance PrimUnlifted (MVar a) where
+  toArrayArray# (MVar mv#) = unsafeCoerce# mv#
+  fromArrayArray# aa# = MVar (unsafeCoerce# aa#)
+
+instance PrimUnlifted (IORef a) where
+  toArrayArray# (IORef (STRef mv#)) = unsafeCoerce# mv#
+  fromArrayArray# aa# = IORef (STRef (unsafeCoerce# aa#))
+
+instance PrimUnlifted (STRef s a) where
+  toArrayArray# (STRef mv#) = unsafeCoerce# mv#
+  fromArrayArray# aa# = STRef (unsafeCoerce# aa#)
+
+instance PrimUnlifted (TVar a) where
+  toArrayArray# (TVar mv#) = unsafeCoerce# mv#
+  fromArrayArray# aa# = TVar (unsafeCoerce# aa#)
 
 -- | Creates a new 'MutableUnliftedArray'. This function is unsafe, because it
 -- allows access to the raw contents of the underlying 'ArrayArray#'.

--- a/cbits/primitive-memops.c
+++ b/cbits/primitive-memops.c
@@ -49,3 +49,7 @@ MEMSET(Ptr, HsPtr)
 MEMSET(Float, HsFloat)
 MEMSET(Double, HsDouble)
 MEMSET(Char, HsChar)
+
+int hsprimitive_is_byte_array_pinned(void* p){
+    return Bdescr((StgPtr)p)->flags & (BF_PINNED | BF_LARGE);
+}

--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <HsFFI.h>
+#include <Rts.h>
 
 void hsprimitive_memcpy( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
 void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
@@ -18,5 +19,6 @@ void hsprimitive_memset_Float (HsFloat *, ptrdiff_t, size_t, HsFloat);
 void hsprimitive_memset_Double (HsDouble *, ptrdiff_t, size_t, HsDouble);
 void hsprimitive_memset_Char (HsChar *, ptrdiff_t, size_t, HsChar);
 
+int hsprimitive_is_byte_array_pinned(void* p);
 #endif
 

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -51,8 +51,8 @@ Library
   Build-Depends: base >= 4.5 && < 4.11
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
-
-  Ghc-Options: -O2 -Wall
+  Build-tools: cpphs >= 1.19
+  Ghc-Options: -O2 -Wall -pgmP cpphs -optP --cpp
 
   Include-Dirs: cbits
   Install-Includes: primitive-memops.h

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -35,7 +35,10 @@ Library
         Data.Primitive.MachDeps
         Data.Primitive.Types
         Data.Primitive.Array
+        Data.Primitive.Array.Class
+        Data.Primitive.Array.Checked
         Data.Primitive.ByteArray
+        Data.Primitive.PrimArray
         Data.Primitive.SmallArray
         Data.Primitive.UnliftedArray
         Data.Primitive.Addr

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -51,8 +51,7 @@ Library
   Build-Depends: base >= 4.5 && < 4.11
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
-  Build-tools: cpphs >= 1.19
-  Ghc-Options: -O2 -Wall -pgmP cpphs -optP --cpp
+  Ghc-Options: -O2 -Wall
 
   Include-Dirs: cbits
   Install-Includes: primitive-memops.h


### PR DESCRIPTION
This is the `PrimArray` patch as @bgamari requested, This patch also offer polymorphric `Arr` class which unify boxed and unboxed array interface. Please review carefully because there may be bugs ; ) 

~~I haven't consider much compatibility issue when i'm doing this, so please add whatever `CPP` needed to make it work on older GHCs.~~ I have added `CPP`s and CI is happy now.

~~I'm planning to make another patch which bring `foldr/build` fusion to these arrays, please don't cut a new release before that is done.~~ I believe fusion belongs to high level vector package now, so this is the full patch already, please review and merge(if there's no objections) ASAP. 