### PR TITLE
Adapt to the Semigroup–Monoid Proposal

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -52,6 +52,9 @@ import Data.Foldable (Foldable(..), toList)
 import Data.Traversable (Traversable(..))
 import Data.Monoid
 #endif
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup
+#endif
 
 import Text.ParserCombinators.ReadP
 
@@ -272,7 +275,7 @@ cloneArray :: Array a -- ^ source array
            -> Array a
 {-# INLINE cloneArray #-}
 #if __GLASGOW_HASKELL__ >= 702
-cloneArray (Array arr#) (I# off#) (I# len#) 
+cloneArray (Array arr#) (I# off#) (I# len#)
   = case cloneArray# arr# off# len# of arr'# -> Array arr'#
 #else
 cloneArray arr off len = runST $ do
@@ -528,9 +531,16 @@ instance MonadZip Array where
 instance MonadFix Array where
   mfix f = let l = mfix (toList . f) in fromListN (length l) l
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup (Array a) where
+  (<>) = (<|>)
+#endif
+
 instance Monoid (Array a) where
   mempty = empty
+#if !(MIN_VERSION_base(4,11,0))
   mappend = (<|>)
+#endif
   mconcat l = createArray sz (die "mconcat" "impossible") $ \ma ->
     let go !_  [    ] = return ()
         go off (a:as) =

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -78,7 +78,7 @@ import Data.Foldable
 import Data.Functor.Identity
 import Data.Monoid
 #if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup
+import qualified Data.Semigroup as Sem
 #endif
 import Text.ParserCombinators.ReadPrec
 import Text.Read
@@ -579,7 +579,7 @@ instance MonadFix SmallArray where
   mfix f = fromList . mfix $ toList . f
 
 #if MIN_VERSION_base(4,9,0)
-instance Semigroup (SmallArray a) where
+instance Sem.Semigroup (SmallArray a) where
   (<>) = (<|>)
 #endif
 

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -77,6 +77,9 @@ import Data.Data
 import Data.Foldable
 import Data.Functor.Identity
 import Data.Monoid
+#if MIN_VERSION_base(4,9,0) && !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup
+#endif
 import Text.ParserCombinators.ReadPrec
 import Text.Read
 import Text.Read.Lex
@@ -575,9 +578,16 @@ instance MonadZip SmallArray where
 instance MonadFix SmallArray where
   mfix f = fromList . mfix $ toList . f
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup (SmallArray a) where
+  (<>) = (<|>)
+#endif
+
 instance Monoid (SmallArray a) where
   mempty = empty
+#if !(MIN_VERSION_base(4,11,0))
   mappend = (<|>)
+#endif
   mconcat sas = createSmallArray n (die "mconcat" "impossible") $ \sma ->
     fix ? 0 ? sas $ \go off l -> case l of
       [] -> return ()


### PR DESCRIPTION
In the next version of `base` (4.11), `Semigroup` will be a superclass of `Monoid`. This PR updates `primitive` accordingly by adding missing `Semigroup` instances.