### PR TITLE
Add sconcat implementations to Semigroup instances

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -34,6 +34,7 @@ import qualified GHC.Exts as Exts
 import GHC.Exts (fromListN, fromList)
 #endif
 
+import qualified Data.Foldable as F
 import Data.Typeable ( Typeable )
 import Data.Data
   (Data(..), DataType, mkDataType, Constr, mkConstr, Fixity(..), constrIndex)
@@ -534,6 +535,7 @@ instance MonadFix Array where
 #if MIN_VERSION_base(4,9,0)
 instance Semigroup (Array a) where
   (<>) = (<|>)
+  sconcat = mconcat . F.toList
 #endif
 
 instance Monoid (Array a) where

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -581,6 +581,7 @@ instance MonadFix SmallArray where
 #if MIN_VERSION_base(4,9,0)
 instance Sem.Semigroup (SmallArray a) where
   (<>) = (<|>)
+  sconcat = mconcat . toList
 #endif
 
 instance Monoid (SmallArray a) where


### PR DESCRIPTION
As of GHC 8.4 Semigroup is a superclass of Monoid. Account for this
where necessary.