### PR TITLE
add Semigroup and Monoid instances for ByteArray

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -65,6 +65,10 @@ import qualified Data.Semigroup as SG
 import qualified Data.Foldable as F
 #endif
 
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Monoid (Monoid(..))
+#endif
+
 -- | Byte arrays
 data ByteArray = ByteArray ByteArray# deriving ( Typeable )
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -8,11 +8,13 @@ import Data.Primitive
 import Data.Primitive.Array
 import Data.Primitive.ByteArray
 import Data.Primitive.Types
-import Data.Semigroup (stimes)
 import Data.Word
 import GHC.Int
 import GHC.IO
 import GHC.Prim
+#if MIN_VERSION_base(4,9,0)
+import Data.Semigroup (stimes)
+#endif
 
 -- Since we only have two test cases right now, I'm going to avoid the
 -- issue of choosing a test framework for the moment. This also keeps the

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE CPP, MagicHash, UnboxedTuples #-}
 
 import Control.Monad
 import Control.Monad.Primitive
@@ -57,8 +57,10 @@ testByteArray = do
         fail $ "ByteArray Monoid mappend not associative"
     unless (mconcat [arr1,arr2,arr3,arr4,arr5] == (arr1 <> arr2 <> arr3 <> arr4 <> arr5)) $
         fail $ "ByteArray Monoid mconcat incorrect"
+#if MIN_VERSION_base(4,9,0)
     unless (stimes (3 :: Int) arr4 == (arr4 <> arr4 <> arr4)) $
         fail $ "ByteArray Semigroup stimes incorrect"
+#endif
 
 mkByteArray :: Prim a => [a] -> ByteArray
 mkByteArray xs = runST $ do

--- a/test/main.hs
+++ b/test/main.hs
@@ -3,10 +3,12 @@
 import Control.Monad
 import Control.Monad.Primitive
 import Control.Monad.ST
+import Data.Monoid
 import Data.Primitive
 import Data.Primitive.Array
 import Data.Primitive.ByteArray
 import Data.Primitive.Types
+import Data.Semigroup (stimes)
 import Data.Word
 import GHC.Int
 import GHC.IO
@@ -41,12 +43,22 @@ testByteArray = do
     let arr1 = mkByteArray ([0xde, 0xad, 0xbe, 0xef] :: [Word8])
         arr2 = mkByteArray ([0xde, 0xad, 0xbe, 0xef] :: [Word8])
         arr3 = mkByteArray ([0xde, 0xad, 0xbe, 0xee] :: [Word8])
+        arr4 = mkByteArray ([0xde, 0xad, 0xbe, 0xdd] :: [Word8])
+        arr5 = mkByteArray ([0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xdd] :: [Word8])
     when (show arr1 /= "[0xde, 0xad, 0xbe, 0xef]") $
         fail $ "ByteArray Show incorrect: "++show arr1
     unless (arr1 > arr3) $
         fail $ "ByteArray Ord incorrect"
     unless (arr1 == arr2) $
         fail $ "ByteArray Eq incorrect"
+    unless (mappend arr1 arr4 == arr5) $
+        fail $ "ByteArray Monoid mappend incorrect"
+    unless (mappend arr1 (mappend arr3 arr4) == mappend (mappend arr1 arr3) arr4) $
+        fail $ "ByteArray Monoid mappend not associative"
+    unless (mconcat [arr1,arr2,arr3,arr4,arr5] == (arr1 <> arr2 <> arr3 <> arr4 <> arr5)) $
+        fail $ "ByteArray Monoid mconcat incorrect"
+    unless (stimes (3 :: Int) arr4 == (arr4 <> arr4 <> arr4)) $
+        fail $ "ByteArray Semigroup stimes incorrect"
 
 mkByteArray :: Prim a => [a] -> ByteArray
 mkByteArray xs = runST $ do


### PR DESCRIPTION
Implements Semigroup and Monoid instances for ByteArray described in https://github.com/haskell/primitive/issues/76

This code has not yet been tested. The functions `sconcat`, `stimes`, and `mconcat` are given implementations that are asymptotically superior to the default implementations.