### PR TITLE
Copy bytearray addr

### DIFF
--- a/Data/Primitive/Addr.hs
+++ b/Data/Primitive/Addr.hs
@@ -31,7 +31,9 @@ module Data.Primitive.Addr (
 
 import Control.Monad.Primitive
 import Data.Primitive.Types
+#if __GLASGOW_HASKELL__ >= 708
 import Data.Primitive.ByteArray
+#endif
 
 import GHC.Base ( Int(..) )
 import GHC.Prim

--- a/Data/Primitive/Addr.hs
+++ b/Data/Primitive/Addr.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash, UnboxedTuples #-}
+{-# LANGUAGE MagicHash, UnboxedTuples, CPP #-}
 
 -- |
 -- Module      : Data.Primitive.Addr
@@ -22,11 +22,16 @@ module Data.Primitive.Addr (
   indexOffAddr, readOffAddr, writeOffAddr,
 
   -- * Block operations
-  copyAddr, moveAddr, setAddr
+  copyAddr,
+#if __GLASGOW_HASKELL__ >= 702
+  copyAddrToByteArray,
+#endif
+  moveAddr, setAddr
 ) where
 
 import Control.Monad.Primitive
 import Data.Primitive.Types
+import Data.Primitive.ByteArray
 
 import GHC.Base ( Int(..) )
 import GHC.Prim
@@ -83,6 +88,20 @@ copyAddr :: PrimMonad m => Addr         -- ^ destination address
 {-# INLINE copyAddr #-}
 copyAddr (Addr dst#) (Addr src#) n
   = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) n
+
+#if __GLASGOW_HASKELL__ >= 702
+-- | Copy the given number of bytes from the 'Addr' to the 'MutableByteArray'.
+--   The areas may not overlap.
+copyAddrToByteArray :: PrimMonad m
+  => MutableByteArray (PrimState m) -- ^ destination
+  -> Int -- ^ offset into the destination array
+  -> Addr -- ^ source
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+{-# INLINE copyAddrToByteArray #-}
+copyAddrToByteArray (MutableByteArray marr) (I# off) (Addr addr) (I# len) =
+  primitive_ $ copyAddrToByteArray# addr marr off len
+#endif
 
 -- | Copy the given number of bytes from the second 'Addr' to the first. The
 -- areas may overlap.

--- a/Data/Primitive/Addr.hs
+++ b/Data/Primitive/Addr.hs
@@ -23,7 +23,7 @@ module Data.Primitive.Addr (
 
   -- * Block operations
   copyAddr,
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
   copyAddrToByteArray,
 #endif
   moveAddr, setAddr
@@ -89,7 +89,7 @@ copyAddr :: PrimMonad m => Addr         -- ^ destination address
 copyAddr (Addr dst#) (Addr src#) n
   = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) n
 
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
 -- | Copy the given number of bytes from the 'Addr' to the 'MutableByteArray'.
 --   The areas may not overlap.
 copyAddrToByteArray :: PrimMonad m

--- a/Data/Primitive/Addr.hs
+++ b/Data/Primitive/Addr.hs
@@ -91,7 +91,8 @@ copyAddr (Addr dst#) (Addr src#) n
 
 #if __GLASGOW_HASKELL__ >= 708
 -- | Copy the given number of bytes from the 'Addr' to the 'MutableByteArray'.
---   The areas may not overlap.
+--   The areas may not overlap. This function is only available when compiling
+--   with GHC 7.8 or newer.
 copyAddrToByteArray :: PrimMonad m
   => MutableByteArray (PrimState m) -- ^ destination
   -> Int -- ^ offset into the destination array

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -238,7 +238,8 @@ copyMutableByteArray (MutableByteArray dst#) doff
 
 #if __GLASGOW_HASKELL__ >= 708
 -- | Copy a slice of a byte array to an unmanaged address. These must not
---   overlap.
+--   overlap. This function is only available when compiling with GHC 7.8
+--   or newer.
 copyByteArrayToAddr
   :: PrimMonad m
   => Addr -- ^ destination
@@ -253,7 +254,8 @@ copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff sz
 
 #if __GLASGOW_HASKELL__ >= 708
 -- | Copy a slice of a mutable byte array to an unmanaged address. These must
---   not overlap.
+--   not overlap. This function is only available when compiling with GHC 7.8
+--   or newer.
 copyMutableByteArrayToAddr
   :: PrimMonad m
   => Addr -- ^ destination

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -237,6 +237,8 @@ copyMutableByteArray (MutableByteArray dst#) doff
 
 
 #if __GLASGOW_HASKELL__ >= 702
+-- | Copy a slice of a byte array to an unmanaged address. These must not
+--   overlap.
 copyByteArrayToAddr
   :: PrimMonad m
   => Addr -- ^ destination
@@ -250,6 +252,8 @@ copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff sz
 #endif
 
 #if __GLASGOW_HASKELL__ >= 702
+-- | Copy a slice of a mutable byte array to an unmanaged address. These must
+--   not overlap.
 copyMutableByteArrayToAddr
   :: PrimMonad m
   => Addr -- ^ destination

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -30,7 +30,11 @@ module Data.Primitive.ByteArray (
   unsafeFreezeByteArray, unsafeThawByteArray,
 
   -- * Block operations
-  copyByteArray, copyMutableByteArray, moveByteArray,
+  copyByteArray, copyMutableByteArray,
+#if __GLASGOW_HASKELL__ >= 702
+  copyByteArrayToAddr, copyMutableByteArrayToAddr,
+#endif
+  moveByteArray,
   setByteArray, fillByteArray,
 
   -- * Information
@@ -229,6 +233,33 @@ copyMutableByteArray (MutableByteArray dst#) doff
   = unsafePrimToPrim
   $ memcpy_mba dst# (fromIntegral doff) src# (fromIntegral soff)
                     (fromIntegral sz)
+#endif
+
+
+#if __GLASGOW_HASKELL__ >= 702
+copyByteArrayToAddr
+  :: PrimMonad m
+  => Addr -- ^ destination
+  -> ByteArray -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+{-# INLINE copyByteArrayToAddr #-}
+copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff sz
+  = primitive_ (copyByteArrayToAddr# src# (unI# soff) dst# (unI# sz))
+#endif
+
+#if __GLASGOW_HASKELL__ >= 702
+copyMutableByteArrayToAddr
+  :: PrimMonad m
+  => Addr -- ^ destination
+  -> MutableByteArray (PrimState m) -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+{-# INLINE copyMutableByteArrayToAddr #-}
+copyMutableByteArrayToAddr (Addr dst#) (MutableByteArray src#) soff sz
+  = primitive_ (copyMutableByteArrayToAddr# src# (unI# soff) dst# (unI# sz))
 #endif
 
 -- | Copy a slice of a mutable byte array into another, potentially

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -31,7 +31,7 @@ module Data.Primitive.ByteArray (
 
   -- * Block operations
   copyByteArray, copyMutableByteArray,
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
   copyByteArrayToAddr, copyMutableByteArrayToAddr,
 #endif
   moveByteArray,
@@ -236,7 +236,7 @@ copyMutableByteArray (MutableByteArray dst#) doff
 #endif
 
 
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
 -- | Copy a slice of a byte array to an unmanaged address. These must not
 --   overlap.
 copyByteArrayToAddr
@@ -251,7 +251,7 @@ copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff sz
   = primitive_ (copyByteArrayToAddr# src# (unI# soff) dst# (unI# sz))
 #endif
 
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 708
 -- | Copy a slice of a mutable byte array to an unmanaged address. These must
 --   not overlap.
 copyMutableByteArrayToAddr

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -250,9 +250,7 @@ copyByteArrayToAddr
 {-# INLINE copyByteArrayToAddr #-}
 copyByteArrayToAddr (Addr dst#) (ByteArray src#) soff sz
   = primitive_ (copyByteArrayToAddr# src# (unI# soff) dst# (unI# sz))
-#endif
 
-#if __GLASGOW_HASKELL__ >= 708
 -- | Copy a slice of a mutable byte array to an unmanaged address. These must
 --   not overlap. This function is only available when compiling with GHC 7.8
 --   or newer.


### PR DESCRIPTION
Resolves https://github.com/haskell/primitive/issues/80

Currently, this does not provide these functions for users of older GHCs. I'm not sure if this how important this is. Also, I'm not sure when the primitives for copying between a byte array and an address were introduced to `ghc-prim`. I guessed GHC 7.2, but hopefully travis will let me know if I guessed wrong.