### PR TITLE
Move tests to separate .cabal file 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,15 +93,16 @@ install:
       cabal new-update head.hackage -v
     fi
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - "printf 'packages: \".\"\\n' > cabal.project"
+  - "printf 'packages: \".\" \"./test\"\\n' > cabal.project"
   - cat cabal.project
   - if [ -f "./configure.ac" ]; then
       (cd "." && autoreconf -i);
     fi
+  - if [ -f "./test/configure.ac" ]; then
+      (cd "./test" && autoreconf -i);
+    fi
   - rm -f cabal.project.freeze
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
-  - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
-  - rm -rf "."/.ghc.environment.* "."/dist
+  - rm -rf .ghc.environment.* "."/dist "./test"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
@@ -109,10 +110,11 @@ install:
 script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
-  - mv "."/dist/primitive-*.tar.gz ${DISTDIR}/
+  - (cd "./test" && cabal sdist)
+  - mv "."/dist/primitive-*.tar.gz "./test"/dist/primitive-tests-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-  - "printf 'packages: primitive-*/*.cabal\\n' > cabal.project"
+  - "printf 'packages: primitive-*/*.cabal primitive-tests-*/*.cabal\\n' > cabal.project"
   - cat cabal.project
   # this builds all libraries and executables (without tests/benchmarks)
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks all
@@ -121,12 +123,12 @@ script:
   - if $INSTALLED; then echo cabal new-build -w ${HC} --disable-tests --disable-benchmarks $(${HCPKG} list --global --simple-output --names-only | sed 's/\([a-zA-Z0-9-]\{1,\}\) */--constraint="\1 installed" /g') all | sh; else echo "Not building with installed constraints"; fi
 
   # build & run tests, build benchmarks
-  - cabal new-build -w ${HC} ${TEST} ${BENCH} all
+  - cabal new-build -w ${HC} ${TEST} ${BENCH} -j2 all
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
-  #   Commented out due to https://github.com/haskell/cabal/issues/4551
-  # - (cd primitive-* && cabal check)
+  - (cd primitive-* && cabal check)
+  - (cd primitive-tests-* && cabal check)
 
   # haddock
   - rm -rf ./dist-newstyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,8 @@ script:
   - if [ "x$TEST" = "x--enable-tests" ]; then cabal new-test -w ${HC} ${TEST} ${BENCH} all; fi
 
   # cabal check
-  - (cd primitive-* && cabal check)
+  #   Commented out due to https://github.com/haskell/cabal/issues/4551
+  # - (cd primitive-* && cabal check)
   - (cd primitive-tests-* && cabal check)
 
   # haddock

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,2 @@
 packages: .
+          ./test

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -15,6 +15,9 @@ Build-Type:     Simple
 Description:    This package provides various primitive memory-related operations.
 
 Extra-Source-Files: changelog.md
+                    test/*.hs
+                    test/LICENSE
+                    test/primitive-tests.cabal
 
 Tested-With:
   GHC == 7.4.2,
@@ -62,16 +65,6 @@ Library
       cc-options: -ftree-vectorize
   if arch(i386) || arch(x86_64)
       cc-options: -msse2
-
-test-suite test
-  Default-Language: Haskell2010
-  hs-source-dirs: test
-  main-is: main.hs
-  type: exitcode-stdio-1.0
-  build-depends: base
-               , ghc-prim
-               , primitive
-  ghc-options: -O2
 
 source-repository head
   type:     git

--- a/test/LICENSE
+++ b/test/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2008-2009, Roman Leshchinskiy
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -1,0 +1,38 @@
+Name:           primitive-tests
+Version:        0.1
+License:        BSD3
+License-File:   LICENSE
+
+Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
+Maintainer:     libraries@haskell.org
+Copyright:      (c) Roman Leshchinskiy 2009-2012
+Homepage:       https://github.com/haskell/primitive
+Bug-Reports:    https://github.com/haskell/primitive/issues
+Category:       Data
+Synopsis:       primitive tests
+Cabal-Version:  >= 1.10
+Build-Type:     Simple
+Description:    @primitive@ tests
+
+Tested-With:
+  GHC == 7.4.2,
+  GHC == 7.6.3,
+  GHC == 7.8.4,
+  GHC == 7.10.3,
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.1
+
+test-suite test
+  Default-Language: Haskell2010
+  hs-source-dirs: .
+  main-is: main.hs
+  type: exitcode-stdio-1.0
+  build-depends: base
+               , ghc-prim
+               , primitive
+  ghc-options: -O2
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/primitive

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -28,7 +28,7 @@ test-suite test
   hs-source-dirs: .
   main-is: main.hs
   type: exitcode-stdio-1.0
-  build-depends: base
+  build-depends: base >= 4.5 && < 4.12
                , ghc-prim
                , primitive
   ghc-options: -O2


### PR DESCRIPTION
This is a preparatory refactor towards #89. This moves the test suite into a separate `.cabal` file so that in the future, we can modify the test suite to depend on libraries that depend on `primitive` itself, such as `QuickCheck`.

Note that this does not change any of the code in the test suite itself—let's save that for a separate commit.