### PR TITLE
Implement PrimArray

### DIFF
--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -16,7 +16,6 @@
 
 module Control.Monad.Primitive (
   PrimMonad(..), RealWorld, primitive_,
-  PrimAffineMonad,
   PrimBase(..),
   liftPrim, primToPrim, primToIO, primToST, ioToPrim, stToPrim,
   unsafePrimToPrim, unsafePrimToIO, unsafePrimToST, unsafeIOToPrim,
@@ -74,8 +73,6 @@ class Monad m => PrimMonad m where
   -- | Execute a primitive operation
   primitive :: (State# (PrimState m) -> (# State# (PrimState m), a #)) -> m a
 
-class PrimMonad m => PrimAffineMonad m where
-
 -- | Class of primitive monads for state-transformer actions.
 --
 -- Unlike 'PrimMonad', this typeclass requires that the @Monad@ be fully
@@ -97,7 +94,6 @@ instance PrimMonad IO where
   type PrimState IO = RealWorld
   primitive = IO
   {-# INLINE primitive #-}
-instance PrimAffineMonad IO
 instance PrimBase IO where
   internal (IO p) = p
   {-# INLINE internal #-}
@@ -111,7 +107,6 @@ instance PrimMonad m => PrimMonad (IdentityT m) where
   type PrimState (IdentityT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (IdentityT m) where
 instance PrimBase m => PrimBase (IdentityT m) where
   internal (IdentityT m) = internal m
   {-# INLINE internal #-}
@@ -125,44 +120,37 @@ instance PrimMonad m => PrimMonad (MaybeT m) where
   type PrimState (MaybeT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (MaybeT m)
 
 instance (Error e, PrimMonad m) => PrimMonad (ErrorT e m) where
   type PrimState (ErrorT e m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance (Error e, PrimAffineMonad m) => PrimAffineMonad (ErrorT e m)
 
 instance PrimMonad m => PrimMonad (ReaderT r m) where
   type PrimState (ReaderT r m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (ReaderT r m)
 
 instance PrimMonad m => PrimMonad (StateT s m) where
   type PrimState (StateT s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (StateT s m)
 
 instance (Monoid w, PrimMonad m) => PrimMonad (WriterT w m) where
   type PrimState (WriterT w m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (WriterT w m)
 
 instance (Monoid w, PrimMonad m) => PrimMonad (RWST r w s m) where
   type PrimState (RWST r w s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (RWST r w s m)
 
 #if MIN_VERSION_transformers(0,4,0)
 instance PrimMonad m => PrimMonad (ExceptT e m) where
   type PrimState (ExceptT e m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (ExceptT e m)
 #endif
 
 #if MIN_VERSION_transformers(0,5,3)
@@ -185,25 +173,21 @@ instance PrimMonad m => PrimMonad (Strict.StateT s m) where
   type PrimState (Strict.StateT s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance PrimAffineMonad m => PrimAffineMonad (Strict.StateT s m)
 
 instance (Monoid w, PrimMonad m) => PrimMonad (Strict.WriterT w m) where
   type PrimState (Strict.WriterT w m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (Strict.WriterT w m) where
 
 instance (Monoid w, PrimMonad m) => PrimMonad (Strict.RWST r w s m) where
   type PrimState (Strict.RWST r w s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
-instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (Strict.RWST r w s m) where
 
 instance PrimMonad (ST s) where
   type PrimState (ST s) = s
   primitive = ST
   {-# INLINE primitive #-}
-instance PrimAffineMonad (ST s) where
 instance PrimBase (ST s) where
   internal (ST p) = p
   {-# INLINE internal #-}

--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -16,6 +16,7 @@
 
 module Control.Monad.Primitive (
   PrimMonad(..), RealWorld, primitive_,
+  PrimAffineMonad,
   PrimBase(..),
   liftPrim, primToPrim, primToIO, primToST, ioToPrim, stToPrim,
   unsafePrimToPrim, unsafePrimToIO, unsafePrimToST, unsafeIOToPrim,
@@ -73,6 +74,8 @@ class Monad m => PrimMonad m where
   -- | Execute a primitive operation
   primitive :: (State# (PrimState m) -> (# State# (PrimState m), a #)) -> m a
 
+class PrimMonad m => PrimAffineMonad m where
+
 -- | Class of primitive monads for state-transformer actions.
 --
 -- Unlike 'PrimMonad', this typeclass requires that the @Monad@ be fully
@@ -94,6 +97,7 @@ instance PrimMonad IO where
   type PrimState IO = RealWorld
   primitive = IO
   {-# INLINE primitive #-}
+instance PrimAffineMonad IO
 instance PrimBase IO where
   internal (IO p) = p
   {-# INLINE internal #-}
@@ -102,47 +106,63 @@ instance PrimMonad m => PrimMonad (ContT r m) where
   type PrimState (ContT r m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+
 instance PrimMonad m => PrimMonad (IdentityT m) where
   type PrimState (IdentityT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (IdentityT m) where
 instance PrimBase m => PrimBase (IdentityT m) where
   internal (IdentityT m) = internal m
   {-# INLINE internal #-}
+
 instance PrimMonad m => PrimMonad (ListT m) where
   type PrimState (ListT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+
 instance PrimMonad m => PrimMonad (MaybeT m) where
   type PrimState (MaybeT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (MaybeT m)
+
 instance (Error e, PrimMonad m) => PrimMonad (ErrorT e m) where
   type PrimState (ErrorT e m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance (Error e, PrimAffineMonad m) => PrimAffineMonad (ErrorT e m)
+
 instance PrimMonad m => PrimMonad (ReaderT r m) where
   type PrimState (ReaderT r m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (ReaderT r m)
+
 instance PrimMonad m => PrimMonad (StateT s m) where
   type PrimState (StateT s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (StateT s m)
+
 instance (Monoid w, PrimMonad m) => PrimMonad (WriterT w m) where
   type PrimState (WriterT w m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (WriterT w m)
+
 instance (Monoid w, PrimMonad m) => PrimMonad (RWST r w s m) where
   type PrimState (RWST r w s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (RWST r w s m)
 
 #if MIN_VERSION_transformers(0,4,0)
 instance PrimMonad m => PrimMonad (ExceptT e m) where
   type PrimState (ExceptT e m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (ExceptT e m)
 #endif
 
 #if MIN_VERSION_transformers(0,5,3)
@@ -165,19 +185,25 @@ instance PrimMonad m => PrimMonad (Strict.StateT s m) where
   type PrimState (Strict.StateT s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance PrimAffineMonad m => PrimAffineMonad (Strict.StateT s m)
+
 instance (Monoid w, PrimMonad m) => PrimMonad (Strict.WriterT w m) where
   type PrimState (Strict.WriterT w m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (Strict.WriterT w m) where
+
 instance (Monoid w, PrimMonad m) => PrimMonad (Strict.RWST r w s m) where
   type PrimState (Strict.RWST r w s m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+instance (Monoid w, PrimAffineMonad m) => PrimAffineMonad (Strict.RWST r w s m) where
 
 instance PrimMonad (ST s) where
   type PrimState (ST s) = s
   primitive = ST
   {-# INLINE primitive #-}
+instance PrimAffineMonad (ST s) where
 instance PrimBase (ST s) where
   internal (ST p) = p
   {-# INLINE internal #-}

--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -11,6 +11,7 @@
 -- Reexports all primitive operations
 --
 module Data.Primitive (
+  -- * Re-exports
   module Data.Primitive.Types,
   module Data.Primitive.Array,
   module Data.Primitive.ByteArray,
@@ -20,6 +21,8 @@ module Data.Primitive (
   module Data.Primitive.PrimArray,
 
   sizeOf, alignment
+  -- * Naming Conventions
+  -- $namingConventions
 ) where
 
 import Data.Primitive.Types
@@ -29,3 +32,54 @@ import Data.Primitive.Addr
 import Data.Primitive.SmallArray
 import Data.Primitive.UnliftedArray
 import Data.Primitive.PrimArray
+
+{- $namingConventions
+For historical reasons, this library embraces the practice of suffixing
+the name of a function with the type it operates on. For example, three
+of the variants of the array indexing function are:
+
+> indexArray      ::           Array      a -> Int -> a
+> indexSmallArray ::           SmallArray a -> Int -> a
+> indexPrimArray  :: Prim a => PrimArray  a -> Int -> a
+
+In a few places, where the language sounds more natural, the array type
+is instead used as a prefix. For example, @Data.Primitive.SmallArray@
+exports @smallArrayFromList@, which would sound unnatural if it used
+@SmallArray@ as a suffix instead.
+
+This library provides several functions traversing, building, and filtering
+arrays. These functions are suffixed with an additional character to
+indicate their the nature of their effectfulness:
+
+* No suffix: A non-effectful pass over the array.
+* @-A@ suffix: An effectful pass over the array, where the effect is 'Applicative'.
+* @-P@ suffix: An effectful pass over the array, where the effect is 'PrimMonad'.
+
+Additionally, an apostrophe can be used to indicate strictness in the elements.
+The variants with an apostrophe are used in @Data.Primitive.Array@ but not
+in @Data.Primitive.PrimArray@ since the array type it provides is always strict in the element.
+For example, there are three variants of the function that filters elements
+from a primitive array.
+
+> filterPrimArray  :: (Prim a               ) => (a ->   Bool) -> PrimArray a ->    PrimArray a
+> filterPrimArrayA :: (Prim a, Applicative f) => (a -> f Bool) -> PrimArray a -> f (PrimArray a)
+> filterPrimArrayP :: (Prim a, PrimMonad   m) => (a -> m Bool) -> PrimArray a -> m (PrimArray a)
+
+As long as the effectful context is a monad that is sufficiently affine
+the behaviors of the 'Applicative' and 'PrimMonad' variants produce the same results
+and differ only in their strictness. Monads that are sufficiently affine
+include:
+
+* 'IO' and 'ST'
+* Any combination of 'MaybeT', 'ExceptT', 'StateT' and 'Writer' on top
+  of another sufficiently affine monad.
+
+There is one situation where the names deviate from effectful suffix convention
+described above. Throughout the haskell ecosystem, the 'Applicative' variant of
+'map' is known as 'traverse', not @mapA@. Consequently, we adopt the following
+naming convention for mapping:
+
+> mapPrimArray :: (Prim a, Prim b) => (a -> b) -> PrimArray a -> PrimArray b
+> traversePrimArray :: (Applicative f, Prim a, Prim b) => (a -> f b) -> PrimArray a -> f (PrimArray b)
+> traversePrimArrayP :: (PrimMonad m, Prim a, Prim b) => (a -> m b) -> PrimArray a -> m (PrimArray b)
+-}

--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -17,6 +17,7 @@ module Data.Primitive (
   module Data.Primitive.Addr,
   module Data.Primitive.SmallArray,
   module Data.Primitive.UnliftedArray,
+  module Data.Primitive.PrimArray,
 
   sizeOf, alignment
 ) where
@@ -27,3 +28,4 @@ import Data.Primitive.ByteArray
 import Data.Primitive.Addr
 import Data.Primitive.SmallArray
 import Data.Primitive.UnliftedArray
+import Data.Primitive.PrimArray

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -70,6 +70,7 @@ module Data.Primitive.PrimArray
 
 import GHC.Prim
 import GHC.Base ( Int(..) )
+import GHC.Exts (build)
 import GHC.Ptr
 import Data.Primitive.Internal.Compat (isTrue#)
 import Data.Primitive
@@ -150,8 +151,9 @@ primArrayFromListN len vs = runST run where
     go vs 0
     unsafeFreezePrimArray arr
 
+{-# INLINE primArrayToList #-}
 primArrayToList :: forall a. Prim a => PrimArray a -> [a]
-primArrayToList = foldrPrimArray (:) []
+primArrayToList xs = build (\c n -> foldrPrimArray c n xs)
 
 primArrayToByteArray :: PrimArray a -> PB.ByteArray
 primArrayToByteArray (PrimArray x) = PB.ByteArray x

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -301,6 +301,9 @@ getSizeofMutablePrimArray (MutablePrimArray arr#)
         (# s'#, sz# #) -> (# s'#, I# (quotInt# sz# (sizeOf# (undefined :: a))) #)
     )
 #else
+-- On older GHCs, it is not possible to resize a byte array, so
+-- this provides behavior consistent with the implementation for
+-- newer GHCs.
 getSizeofMutablePrimArray arr
   = return (sizeofMutablePrimArray arr)
 #endif

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -74,7 +74,7 @@ import GHC.Exts (build)
 import GHC.Ptr
 import Data.Primitive.Internal.Compat (isTrue#)
 import Data.Primitive
-import Data.Monoid (Monoid(..))
+import Data.Monoid (Monoid(..),(<>))
 import Control.Applicative
 import Control.Monad.Primitive
 import Control.Monad.ST

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -494,19 +494,19 @@ foldlPrimArrayM' f z0 arr = go 0 z0
 -- the performance. Consider the following short-circuiting traversal:
 --
 -- > incrPositiveA :: PrimArray Int -> Maybe (PrimArray Int)
--- > incrPositiveA xs = traversePrimArray (\x -> bool Nothing (Just x + 1) (x > 0)) xs
+-- > incrPositiveA xs = traversePrimArray (\x -> bool Nothing (Just (x + 1)) (x > 0)) xs
 --
 -- This can be rewritten using 'traversePrimArrayP'. To do this, we must
 -- change the traversal context to @MaybeT (ST s)@, which has a 'PrimMonad'
 -- instance:
 --
 -- > incrPositiveB :: PrimArray Int -> Maybe (PrimArray Int)
--- > incrPositiveB xs = runST $ traversePrimArrayP
+-- > incrPositiveB xs = runST $ runMaybeT $ traversePrimArrayP
 -- >   (\x -> bool (MaybeT (return Nothing)) (MaybeT (return (Just (x + 1)))) (x > 0))
 -- >   xs
 -- 
--- Benchmarks demonstrate that the second implementation outperforms
--- the first by a factor of X.
+-- Benchmarks demonstrate that the second implementation runs 150 times
+-- faster than the first. It also results in fewer allocations.
 {-# INLINE traversePrimArrayP #-}
 traversePrimArrayP :: (PrimMonad m, Prim a, Prim b)
   => (a -> m b)

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -87,7 +87,7 @@ import GHC.Exts (IsList(..))
 #endif
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Semigroup (Semigroup(..))
+import Data.Semigroup (Semigroup)
 import qualified Data.Semigroup as SG
 #endif
 
@@ -200,7 +200,7 @@ byteArrayToPrimArray (PB.ByteArray x) = PrimArray x
 instance Semigroup (PrimArray a) where
   x <> y = byteArrayToPrimArray (primArrayToByteArray x SG.<> primArrayToByteArray y)
   sconcat = byteArrayToPrimArray . SG.sconcat . fmap primArrayToByteArray
-  stimes i arr = byteArrayToPrimArray (stimes i (primArrayToByteArray arr))
+  stimes i arr = byteArrayToPrimArray (SG.stimes i (primArrayToByteArray arr))
 #endif
 
 instance Monoid (PrimArray a) where

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -111,9 +111,11 @@ sameByteArray ba1 ba2 =
 instance (Eq a, Prim a) => Eq (PrimArray a) where
   a1@(PrimArray ba1#) == a2@(PrimArray ba2#)
     | sameByteArray ba1# ba2# = True
-    | I# (sizeofByteArray# ba1#) /= I# (sizeofByteArray# ba2#) = False
-    | otherwise = loop (sizeofPrimArray a1 - 1)
-    where 
+    | sz1 /= sz2 = False
+    | otherwise = loop sz1
+    where
+    sz1 = PB.sizeofByteArray (ByteArray ba1#)
+    sz2 = PB.sizeofByteArray (ByteArray ba2#)
     loop !i
       | i < 0 = True
       | otherwise = indexPrimArray a1 i == indexPrimArray a2 i && loop (i-1)

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -76,7 +76,8 @@ import GHC.Base ( Int(..) )
 import GHC.Exts (build)
 import GHC.Ptr
 import Data.Primitive.Internal.Compat (isTrue#)
-import Data.Primitive
+import Data.Primitive.Types
+import Data.Primitive.ByteArray (ByteArray(..))
 import Data.Monoid (Monoid(..),(<>))
 import Control.Applicative
 import Control.Monad.Primitive

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -298,7 +298,7 @@ copyMutablePrimArray :: forall m a.
   -> Int -- ^ offset into destination array
   -> MutablePrimArray (PrimState m) a -- ^ source array
   -> Int -- ^ offset into source array
-  -> Int -- ^ number of bytes to copy
+  -> Int -- ^ number of elements to copy
   -> m ()
 {-# INLINE copyMutablePrimArray #-}
 copyMutablePrimArray (MutablePrimArray dst#) (I# doff#) (MutablePrimArray src#) (I# soff#) (I# n#)
@@ -317,7 +317,7 @@ copyPrimArray :: forall m a.
   -> Int -- ^ offset into destination array
   -> PrimArray a -- ^ source array
   -> Int -- ^ offset into source array
-  -> Int -- ^ number of bytes to copy
+  -> Int -- ^ number of elements to copy
   -> m ()
 {-# INLINE copyPrimArray #-}
 copyPrimArray (MutablePrimArray dst#) (I# doff#) (PrimArray src#) (I# soff#) (I# n#)
@@ -379,7 +379,7 @@ setPrimArray
 setPrimArray (MutablePrimArray dst#) (I# doff#) (I# sz#) x
   = primitive_ (PT.setByteArray# dst# doff# sz# x)
 
--- | Get the size of a mutable primitive array in bytes. Unlike 'sizeofMutablePrimArray',
+-- | Get the size of a mutable primitive array in elements. Unlike 'sizeofMutablePrimArray',
 -- this function ensures sequencing in the presence of resizing.
 getSizeofMutablePrimArray :: forall m a. (PrimMonad m, Prim a)
   => MutablePrimArray (PrimState m) a -- ^ array

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+{-# OPTIONS_GHC -Wall #-}
+
+module Data.Primitive.PrimArray
+  ( -- * Types
+    PrimArray(..)
+  , MutablePrimArray(..)
+    -- * Allocation
+  , newPrimArray
+    -- * Element Access
+  , readPrimArray
+  , writePrimArray
+  , indexPrimArray
+    -- * Freezing and Thawing
+  , unsafeFreezePrimArray
+  , unsafeThawPrimArray
+    -- * Block Operations
+  , copyPrimArray
+  , copyMutablePrimArray
+  , copyPrimArrayToPtr
+  , copyMutablePrimArrayToPtr
+  , setPrimArray
+    -- * Information
+  , sameMutablePrimArray
+  , getSizeofMutablePrimArray
+  , sizeofPrimArray
+  ) where
+
+import GHC.Prim
+import GHC.Exts (isTrue#,IsList(..))
+import GHC.Int
+import GHC.Ptr
+import Data.Primitive
+import Control.Monad.Primitive
+import Control.Monad.ST
+import Data.Semigroup (Semigroup(..))
+import qualified Data.Semigroup as SG
+import qualified Data.List as L
+import qualified Data.Primitive.ByteArray as PB
+import qualified Data.Primitive.Types as PT
+
+-- | Primitive arrays
+data PrimArray a = PrimArray ByteArray#
+
+-- | Mutable primitive arrays associated with a primitive state token
+data MutablePrimArray s a = MutablePrimArray (MutableByteArray# s)
+
+instance (Eq a, Prim a) => Eq (PrimArray a) where
+  a1 == a2 = sizeofPrimArray a1 == sizeofPrimArray a2 && loop (sizeofPrimArray a1 - 1)
+    where 
+    loop !i | i < 0 = True
+            | otherwise = indexPrimArray a1 i == indexPrimArray a2 i && loop (i-1)
+
+instance Prim a => IsList (PrimArray a) where
+  type Item (PrimArray a) = a
+  fromList xs = primArrayFromList (L.length xs) xs
+  fromListN = primArrayFromList
+  toList = primArrayToList
+
+instance (Prim a, Show a) => Show (PrimArray a) where
+  showsPrec p = showsPrec p . primArrayToList
+
+primArrayFromList :: forall a. Prim a => Int -> [a] -> PrimArray a
+primArrayFromList len vs = runST run where
+  run :: forall s. ST s (PrimArray a)
+  run = do
+    arr <- newPrimArray len
+    let go :: [a] -> Int -> ST s ()
+        go !xs !ix = case xs of
+          [] -> return ()
+          a : as -> do
+            writePrimArray arr ix a
+            go as (ix + 1)
+    go vs 0
+    unsafeFreezePrimArray arr
+
+primArrayToList :: forall a. Prim a => PrimArray a -> [a]
+primArrayToList arr = go 0 where
+  !len = sizeofPrimArray arr
+  go :: Int -> [a]
+  go !ix = if ix < len
+    then indexPrimArray arr ix : go (ix + 1)
+    else []
+
+primArrayToByteArray :: PrimArray a -> PB.ByteArray
+primArrayToByteArray (PrimArray x) = PB.ByteArray x
+
+byteArrayToPrimArray :: ByteArray -> PrimArray a
+byteArrayToPrimArray (PB.ByteArray x) = PrimArray x
+
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup (PrimArray a) where
+  x <> y = byteArrayToPrimArray (primArrayToByteArray x SG.<> primArrayToByteArray y)
+  sconcat = byteArrayToPrimArray . SG.sconcat . fmap primArrayToByteArray
+  stimes i arr = byteArrayToPrimArray (stimes i (primArrayToByteArray arr))
+#endif
+
+instance Monoid (PrimArray a) where
+  mempty = emptyPrimArray
+#if !(MIN_VERSION_base(4,11,0))
+  mappend x y = byteArrayToPrimArray (mappend (primArrayToByteArray x) (primArrayToByteArray y))
+#endif
+  mconcat = byteArrayToPrimArray . mconcat . map primArrayToByteArray
+
+emptyPrimArray :: PrimArray a
+{-# NOINLINE emptyPrimArray #-}
+emptyPrimArray = runST $ primitive $ \s0# -> case newByteArray# 0# s0# of
+  (# s1#, arr# #) -> case unsafeFreezeByteArray# arr# s1# of
+    (# s2#, arr'# #) -> (# s2#, PrimArray arr'# #)
+
+newPrimArray :: forall m a. (PrimMonad m, Prim a) => Int -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE newPrimArray #-}
+newPrimArray (I# n#)
+  = primitive (\s# -> 
+      case newByteArray# (n# *# sizeOf# (undefined :: a)) s# of
+        (# s'#, arr# #) -> (# s'#, MutablePrimArray arr# #)
+    )
+
+readPrimArray :: (Prim a, PrimMonad m) => MutablePrimArray (PrimState m) a -> Int -> m a
+{-# INLINE readPrimArray #-}
+readPrimArray (MutablePrimArray arr#) (I# i#)
+  = primitive (readByteArray# arr# i#)
+
+writePrimArray ::
+     (Prim a, PrimMonad m)
+  => MutablePrimArray (PrimState m) a
+  -> Int
+  -> a
+  -> m ()
+{-# INLINE writePrimArray #-}
+writePrimArray (MutablePrimArray arr#) (I# i#) x
+  = primitive_ (writeByteArray# arr# i# x)
+
+-- | Copy part of a mutable array into another mutable array.
+--   In the case that the destination and
+--   source arrays are the same, the regions may overlap.
+copyMutablePrimArray :: forall m a.
+     (PrimMonad m, Prim a)
+  => MutablePrimArray (PrimState m) a -- ^ destination array
+  -> Int -- ^ offset into destination array
+  -> MutablePrimArray (PrimState m) a -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+{-# INLINE copyMutablePrimArray #-}
+copyMutablePrimArray (MutablePrimArray dst#) (I# doff#) (MutablePrimArray src#) (I# soff#) (I# n#)
+  = primitive_ (copyMutableByteArray#
+      src# 
+      (soff# *# (sizeOf# (undefined :: a)))
+      dst#
+      (doff# *# (sizeOf# (undefined :: a)))
+      (n# *# (sizeOf# (undefined :: a)))
+    )
+
+-- | Copy part of an array into another mutable array.
+copyPrimArray :: forall m a.
+     (PrimMonad m, Prim a)
+  => MutablePrimArray (PrimState m) a -- ^ destination array
+  -> Int -- ^ offset into destination array
+  -> PrimArray a -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of bytes to copy
+  -> m ()
+{-# INLINE copyPrimArray #-}
+copyPrimArray (MutablePrimArray dst#) (I# doff#) (PrimArray src#) (I# soff#) (I# n#)
+  = primitive_ (copyByteArray#
+      src# 
+      (soff# *# (sizeOf# (undefined :: a)))
+      dst#
+      (doff# *# (sizeOf# (undefined :: a)))
+      (n# *# (sizeOf# (undefined :: a)))
+    )
+
+-- | Copy a slice of an immutable primitive array to an address.
+--   The offset and length are given in elements of type @a@.
+--   This function assumes that the 'Prim' instance of @a@
+--   agrees with the 'Storable' instance.
+copyPrimArrayToPtr :: forall m a. (PrimMonad m, Prim a)
+  => Ptr a -- ^ destination pointer
+  -> PrimArray a -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of prims to copy
+  -> m ()
+{-# INLINE copyPrimArrayToPtr #-}
+copyPrimArrayToPtr (Ptr addr#) (PrimArray ba#) (I# soff#) (I# n#) =
+    primitive (\ s# ->
+        let s'# = copyByteArrayToAddr# ba# (soff# *# siz#) addr# (n# *# siz#) s#
+        in (# s'#, () #))
+  where siz# = sizeOf# (undefined :: a)
+
+-- | Copy a slice of an immutable primitive array to an address.
+--   The offset and length are given in elements of type @a@.
+--   This function assumes that the 'Prim' instance of @a@
+--   agrees with the 'Storable' instance.
+copyMutablePrimArrayToPtr :: forall m a. (PrimMonad m, Prim a)
+  => Ptr a -- ^ destination pointer
+  -> MutablePrimArray (PrimState m) a -- ^ source array
+  -> Int -- ^ offset into source array
+  -> Int -- ^ number of prims to copy
+  -> m ()
+{-# INLINE copyMutablePrimArrayToPtr #-}
+copyMutablePrimArrayToPtr (Ptr addr#) (MutablePrimArray mba#) (I# soff#) (I# n#) =
+    primitive (\ s# ->
+        let s'# = copyMutableByteArrayToAddr# mba# (soff# *# siz#) addr# (n# *# siz#) s#
+        in (# s'#, () #))
+  where siz# = sizeOf# (undefined :: a)
+
+-- | Fill a slice of a mutable byte array with a value.
+setPrimArray
+  :: (Prim a, PrimMonad m)
+  => MutablePrimArray (PrimState m) a -- ^ array to fill
+  -> Int -- ^ offset into array
+  -> Int -- ^ number of values to fill
+  -> a -- ^ value to fill with
+  -> m ()
+{-# INLINE setPrimArray #-}
+setPrimArray (MutablePrimArray dst#) (I# doff#) (I# sz#) x
+  = primitive_ (PT.setByteArray# dst# doff# sz# x)
+
+-- | Get the size of the mutable array.
+getSizeofMutablePrimArray :: forall m a. (PrimMonad m, Prim a)
+  => MutablePrimArray (PrimState m) a -- ^ array
+  -> m Int
+{-# INLINE getSizeofMutablePrimArray #-}
+getSizeofMutablePrimArray (MutablePrimArray arr#)
+  = primitive (\s# -> 
+      case getSizeofMutableByteArray# arr# s# of
+        (# s'#, sz# #) -> (# s'#, I# (quotInt# sz# (sizeOf# (undefined :: a))) #)
+    )
+
+-- | Check if the two arrays refer to the same memory block.
+sameMutablePrimArray :: MutablePrimArray s a -> MutablePrimArray s a -> Bool
+{-# INLINE sameMutablePrimArray #-}
+sameMutablePrimArray (MutablePrimArray arr#) (MutablePrimArray brr#)
+  = isTrue# (sameMutableByteArray# arr# brr#)
+
+-- | Convert a mutable byte array to an immutable one without copying. The
+-- array should not be modified after the conversion.
+unsafeFreezePrimArray
+  :: PrimMonad m => MutablePrimArray (PrimState m) a -> m (PrimArray a)
+{-# INLINE unsafeFreezePrimArray #-}
+unsafeFreezePrimArray (MutablePrimArray arr#)
+  = primitive (\s# -> case unsafeFreezeByteArray# arr# s# of
+                        (# s'#, arr'# #) -> (# s'#, PrimArray arr'# #))
+
+-- | Convert an immutable array to a mutable one without copying. The
+-- original array should not be used after the conversion.
+unsafeThawPrimArray
+  :: PrimMonad m => PrimArray a -> m (MutablePrimArray (PrimState m) a)
+{-# INLINE unsafeThawPrimArray #-}
+unsafeThawPrimArray (PrimArray arr#)
+  = primitive (\s# -> (# s#, MutablePrimArray (unsafeCoerce# arr#) #))
+
+-- | Read a primitive value from the array.
+indexPrimArray :: forall a. Prim a => PrimArray a -> Int -> a
+{-# INLINE indexPrimArray #-}
+indexPrimArray (PrimArray arr#) (I# i#) = indexByteArray# arr# i#
+
+sizeofPrimArray :: forall a. Prim a => PrimArray a -> Int
+{-# INLINE sizeofPrimArray #-}
+sizeofPrimArray (PrimArray arr#) = I# (quotInt# (sizeofByteArray# arr#) (sizeOf# (undefined :: a)))
+

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -72,7 +72,7 @@ module Data.Primitive.PrimArray
   ) where
 
 import GHC.Prim
-import GHC.Exts (isTrue#,IsList(..))
+import GHC.Exts
 import GHC.Base ( Int(..) )
 import GHC.Ptr
 import Data.Primitive
@@ -115,11 +115,13 @@ instance (Eq a, Prim a) => Eq (PrimArray a) where
       | i < 0 = True
       | otherwise = indexPrimArray a1 i == indexPrimArray a2 i && loop (i-1)
 
+#if MIN_VERSION_base(4,7,0)
 instance Prim a => IsList (PrimArray a) where
   type Item (PrimArray a) = a
   fromList xs = primArrayFromListN (L.length xs) xs
   fromListN = primArrayFromListN
   toList = primArrayToList
+#endif
 
 instance (Show a, Prim a) => Show (PrimArray a) where
   showsPrec p a = showParen (p > 10) $

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -209,21 +209,6 @@ primArrayToList xs = build (\c n -> foldrPrimArray c n xs)
 primArrayToByteArray :: PrimArray a -> PB.ByteArray
 primArrayToByteArray (PrimArray x) = PB.ByteArray x
 
--- only used internally, no error checking
-{-# INLINE primArrayFromBackwardsListN #-}
-primArrayFromBackwardsListN :: forall a. Prim a => Int -> [a] -> PrimArray a
-primArrayFromBackwardsListN len vs = runST run where
-  run :: forall s. ST s (PrimArray a)
-  run = do
-    arr <- newPrimArray len
-    let go :: [a] -> Int -> ST s ()
-        go [] !_ = return ()
-        go (a : as) !ix = do
-          writePrimArray arr ix a
-          go as (ix - 1)
-    go vs (len - 1)
-    unsafeFreezePrimArray arr
-
 byteArrayToPrimArray :: ByteArray -> PrimArray a
 byteArrayToPrimArray (PB.ByteArray x) = PrimArray x
 

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -66,11 +66,6 @@ module Data.Primitive.PrimArray
   , itraversePrimArrayP
   , generatePrimArrayP
   , replicatePrimArrayP
-    -- ** Strict Unsafe
-  , traversePrimArrayUnsafe
-  , itraversePrimArrayUnsafe
-  , generatePrimArrayUnsafe
-  , replicatePrimArrayUnsafe
   ) where
 
 import GHC.Prim
@@ -472,18 +467,11 @@ foldlPrimArrayM' f z0 arr = go 0 z0
 -- 2
 -- *** Exception: Prelude.undefined
 {-# INLINE traversePrimArrayP #-}
-traversePrimArrayP :: (PrimAffineMonad m, Prim a, Prim b)
+traversePrimArrayP :: (PrimMonad m, Prim a, Prim b)
   => (a -> m b)
   -> PrimArray a
   -> m (PrimArray b)
-traversePrimArrayP = traversePrimArrayUnsafe
-
-{-# INLINE traversePrimArrayUnsafe #-}
-traversePrimArrayUnsafe :: (PrimMonad m, Prim a, Prim b)
-  => (a -> m b)
-  -> PrimArray a
-  -> m (PrimArray b)
-traversePrimArrayUnsafe f arr = do
+traversePrimArrayP f arr = do
   let !sz = sizeofPrimArray arr
   marr <- newPrimArray sz
   let go !ix = if ix < sz
@@ -496,18 +484,11 @@ traversePrimArrayUnsafe f arr = do
   unsafeFreezePrimArray marr
 
 {-# INLINE generatePrimArrayP #-}
-generatePrimArrayP :: (PrimAffineMonad m, Prim a)
+generatePrimArrayP :: (PrimMonad m, Prim a)
   => Int
   -> (Int -> m a)
   -> m (PrimArray a)
-generatePrimArrayP = generatePrimArrayUnsafe
-
-{-# INLINE generatePrimArrayUnsafe #-}
-generatePrimArrayUnsafe :: (PrimMonad m, Prim a)
-  => Int
-  -> (Int -> m a)
-  -> m (PrimArray a)
-generatePrimArrayUnsafe sz f = do
+generatePrimArrayP sz f = do
   marr <- newPrimArray sz
   let go !ix = if ix < sz
         then do
@@ -519,18 +500,11 @@ generatePrimArrayUnsafe sz f = do
   unsafeFreezePrimArray marr
 
 {-# INLINE replicatePrimArrayP #-}
-replicatePrimArrayP :: (PrimAffineMonad m, Prim a)
+replicatePrimArrayP :: (PrimMonad m, Prim a)
   => Int
   -> m a
   -> m (PrimArray a)
-replicatePrimArrayP = replicatePrimArrayUnsafe
-
-{-# INLINE replicatePrimArrayUnsafe #-}
-replicatePrimArrayUnsafe :: (PrimMonad m, Prim a)
-  => Int
-  -> m a
-  -> m (PrimArray a)
-replicatePrimArrayUnsafe sz f = do
+replicatePrimArrayP sz f = do
   marr <- newPrimArray sz
   let go !ix = if ix < sz
         then do
@@ -696,20 +670,12 @@ itraversePrimArray f = \ !ary ->
      then pure emptyPrimArray
      else runSTA len <$> go 0
 
-
 {-# INLINE itraversePrimArrayP #-}
-itraversePrimArrayP :: (Prim a, Prim b, PrimAffineMonad m)
+itraversePrimArrayP :: (Prim a, Prim b, PrimMonad m)
   => (Int -> a -> m b)
   -> PrimArray a
   -> m (PrimArray b)
-itraversePrimArrayP = itraversePrimArrayUnsafe
-
-{-# INLINE itraversePrimArrayUnsafe #-}
-itraversePrimArrayUnsafe :: (Prim a, Prim b, PrimMonad m)
-  => (Int -> a -> m b)
-  -> PrimArray a
-  -> m (PrimArray b)
-itraversePrimArrayUnsafe f arr = do
+itraversePrimArrayP f arr = do
   let !sz = sizeofPrimArray arr
   marr <- newPrimArray sz
   let go !ix

--- a/bench/PrimArray/Traverse.hs
+++ b/bench/PrimArray/Traverse.hs
@@ -1,0 +1,23 @@
+module PrimArray.Traverse
+  ( benchmarkApplicative
+  , benchmarkPrimMonad
+  , argument
+  ) where
+
+import Control.Monad.ST (runST)
+import Control.Monad.Trans.Maybe (MaybeT(..))
+import Data.Bool (bool)
+import Data.Primitive.PrimArray
+import GHC.Exts (fromList)
+
+benchmarkApplicative :: PrimArray Int -> Maybe (PrimArray Int)
+benchmarkApplicative xs = traversePrimArray (\x -> bool Nothing (Just (x + 1)) (x > 0)) xs
+
+benchmarkPrimMonad :: PrimArray Int -> Maybe (PrimArray Int)
+benchmarkPrimMonad xs = runST $ runMaybeT $ traversePrimArrayP
+  (\x -> bool (MaybeT (return Nothing)) (MaybeT (return (Just (x + 1)))) (x > 0))
+  xs
+
+argument :: PrimArray Int
+argument = fromList (enumFromTo 1 10000)
+

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -32,6 +32,7 @@ import qualified Array.Traverse.Closure
 -- These are particular scenarios that are tested against the
 -- implementations actually used by primitive.
 import qualified ByteArray.Compare
+import qualified PrimArray.Traverse
 
 main :: IO ()
 main = defaultMain
@@ -48,6 +49,14 @@ main = defaultMain
       [ bench "small" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentSmall)
       , bench "medium" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentMedium)
       , bench "large" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentLarge)
+      ]
+    ]
+  , bgroup "PrimArray"
+    [ bgroup "traverse"
+      [ bgroup "Maybe"
+        [ bench "Applicative" (whnf PrimArray.Traverse.benchmarkApplicative PrimArray.Traverse.argument)
+        , bench "PrimMonad" (whnf PrimArray.Traverse.benchmarkPrimMonad PrimArray.Traverse.argument)
+        ]
       ]
     ]
   ]

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -39,6 +39,7 @@ benchmark bench
     Array.Traverse.Closure
     Array.Traverse.Unsafe
     ByteArray.Compare
+    PrimArray.Traverse
   build-depends:
       base >= 4.8 && < 4.12
     , primitive

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## Changes in version 0.6.4.0
 
+ * Introduce `Data.Primitive.PrimArray`, which offers types and function
+   for dealing with a `ByteArray` tagged with a phantom type variable for
+   tracking the element type.
+
  * Add `Eq1`, `Ord1`, `Show1`, and `Read1` instances for `Array` and
    `SmallArray`.
 

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -41,6 +41,7 @@ Library
         Data.Primitive.Types
         Data.Primitive.Array
         Data.Primitive.ByteArray
+        Data.Primitive.PrimArray
         Data.Primitive.SmallArray
         Data.Primitive.UnliftedArray
         Data.Primitive.Addr

--- a/test/main.hs
+++ b/test/main.hs
@@ -91,6 +91,15 @@ main = do
       , TQC.testProperty "imapPrimArray" (QCCL.imapProp int16 int32 imapPrimArray)
       , TQC.testProperty "itraversePrimArray" (QCCL.imapMProp int16 int32 itraversePrimArray)
       , TQC.testProperty "itraversePrimArrayP" (QCCL.imapMProp int16 int32 itraversePrimArrayP)
+      , TQC.testProperty "generatePrimArray" (QCCL.generateProp int16 generatePrimArray)
+      , TQC.testProperty "generatePrimArrayA" (QCCL.generateMProp int16 generatePrimArrayA)
+      , TQC.testProperty "generatePrimArrayP" (QCCL.generateMProp int16 generatePrimArrayP)
+      , TQC.testProperty "replicatePrimArray" (QCCL.replicateProp int16 replicatePrimArray)
+      , TQC.testProperty "replicatePrimArrayA" (QCCL.replicateMProp int16 replicatePrimArrayA)
+      , TQC.testProperty "replicatePrimArrayP" (QCCL.replicateMProp int16 replicatePrimArrayP)
+      , TQC.testProperty "filterPrimArray" (QCCL.filterProp int16 filterPrimArray)
+      , TQC.testProperty "filterPrimArrayA" (QCCL.filterMProp int16 filterPrimArrayA)
+      , TQC.testProperty "witherPrimArray" (QCCL.mapMaybeProp int16 int32 witherPrimArray)
       ]
     ]
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -86,11 +86,11 @@ main = do
       , TQC.testProperty "foldlPrimArray'" (QCCL.foldlProp int16 foldlPrimArray')
       , TQC.testProperty "foldlPrimArrayM'" (QCCL.foldlMProp int16 foldlPrimArrayM')
       , TQC.testProperty "mapPrimArray" (QCCL.mapProp int16 int32 mapPrimArray)
-      , TQC.testProperty "mapPrimArrayM" (QCCL.traverseProp int16 int32 mapPrimArrayM)
-      , TQC.testProperty "mapPrimArrayP" (QCCL.traverseProp int16 int32 mapPrimArrayP)
+      , TQC.testProperty "traversePrimArray" (QCCL.traverseProp int16 int32 traversePrimArray)
+      , TQC.testProperty "traversePrimArrayP" (QCCL.traverseProp int16 int32 traversePrimArrayP)
       , TQC.testProperty "imapPrimArray" (QCCL.imapProp int16 int32 imapPrimArray)
-      , TQC.testProperty "imapPrimArrayM" (QCCL.imapMProp int16 int32 imapPrimArrayM)
-      , TQC.testProperty "imapPrimArrayP" (QCCL.imapMProp int16 int32 imapPrimArrayP)
+      , TQC.testProperty "itraversePrimArray" (QCCL.imapMProp int16 int32 itraversePrimArray)
+      , TQC.testProperty "itraversePrimArrayP" (QCCL.imapMProp int16 int32 itraversePrimArrayP)
       ]
     ]
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -91,6 +91,7 @@ main = do
     , testGroup "PrimArray"
       [ lawsToTest (QCC.eqLaws (Proxy :: Proxy (PrimArray Word16)))
       , lawsToTest (QCC.ordLaws (Proxy :: Proxy (PrimArray Word16)))
+      , lawsToTest (QCC.monoidLaws (Proxy :: Proxy (PrimArray Word16)))
 #if MIN_VERSION_base(4,7,0)
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy (PrimArray Word16)))
       , TQC.testProperty "foldrPrimArray" (QCCL.foldrProp int16 foldrPrimArray)

--- a/test/main.hs
+++ b/test/main.hs
@@ -112,7 +112,10 @@ main = do
       , TQC.testProperty "replicatePrimArrayP" (QCCL.replicateMProp int16 replicatePrimArrayP)
       , TQC.testProperty "filterPrimArray" (QCCL.filterProp int16 filterPrimArray)
       , TQC.testProperty "filterPrimArrayA" (QCCL.filterMProp int16 filterPrimArrayA)
+      , TQC.testProperty "filterPrimArrayP" (QCCL.filterMProp int16 filterPrimArrayP)
       , TQC.testProperty "mapMaybePrimArray" (QCCL.mapMaybeProp int16 int32 mapMaybePrimArray)
+      , TQC.testProperty "mapMaybePrimArrayA" (QCCL.mapMaybeMProp int16 int32 mapMaybePrimArrayA)
+      , TQC.testProperty "mapMaybePrimArrayP" (QCCL.mapMaybeMProp int16 int32 mapMaybePrimArrayP)
 #endif
       ]
     ]

--- a/test/main.hs
+++ b/test/main.hs
@@ -99,7 +99,7 @@ main = do
       , TQC.testProperty "replicatePrimArrayP" (QCCL.replicateMProp int16 replicatePrimArrayP)
       , TQC.testProperty "filterPrimArray" (QCCL.filterProp int16 filterPrimArray)
       , TQC.testProperty "filterPrimArrayA" (QCCL.filterMProp int16 filterPrimArrayA)
-      , TQC.testProperty "witherPrimArray" (QCCL.mapMaybeProp int16 int32 witherPrimArray)
+      , TQC.testProperty "mapMaybePrimArray" (QCCL.mapMaybeProp int16 int32 mapMaybePrimArray)
       ]
     ]
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -79,6 +79,7 @@ main = do
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy ByteArray))
 #endif
       ]
+#if MIN_VERSION_base(4,7,0)
     , testGroup "PrimArray"
       [ TQC.testProperty "foldrPrimArray" (QCCL.foldrProp int16 foldrPrimArray)
       , TQC.testProperty "foldrPrimArray'" (QCCL.foldrProp int16 foldrPrimArray')
@@ -101,6 +102,7 @@ main = do
       , TQC.testProperty "filterPrimArrayA" (QCCL.filterMProp int16 filterPrimArrayA)
       , TQC.testProperty "mapMaybePrimArray" (QCCL.mapMaybeProp int16 int32 mapMaybePrimArray)
       ]
+#endif
     ]
 
 int16 :: Proxy Int16

--- a/test/main.hs
+++ b/test/main.hs
@@ -79,9 +79,12 @@ main = do
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy ByteArray))
 #endif
       ]
-#if MIN_VERSION_base(4,7,0)
     , testGroup "PrimArray"
-      [ TQC.testProperty "foldrPrimArray" (QCCL.foldrProp int16 foldrPrimArray)
+      [ lawsToTest (QCC.eqLaws (Proxy :: Proxy (PrimArray Word16)))
+      , lawsToTest (QCC.ordLaws (Proxy :: Proxy (PrimArray Word16)))
+#if MIN_VERSION_base(4,7,0)
+      , lawsToTest (QCC.isListLaws (Proxy :: Proxy (PrimArray Word16)))
+      , TQC.testProperty "foldrPrimArray" (QCCL.foldrProp int16 foldrPrimArray)
       , TQC.testProperty "foldrPrimArray'" (QCCL.foldrProp int16 foldrPrimArray')
       , TQC.testProperty "foldlPrimArray" (QCCL.foldlProp int16 foldlPrimArray)
       , TQC.testProperty "foldlPrimArray'" (QCCL.foldlProp int16 foldlPrimArray')
@@ -101,8 +104,8 @@ main = do
       , TQC.testProperty "filterPrimArray" (QCCL.filterProp int16 filterPrimArray)
       , TQC.testProperty "filterPrimArrayA" (QCCL.filterMProp int16 filterPrimArrayA)
       , TQC.testProperty "mapMaybePrimArray" (QCCL.mapMaybeProp int16 int32 mapMaybePrimArray)
-      ]
 #endif
+      ]
     ]
 
 int16 :: Proxy Int16

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -36,7 +36,7 @@ test-suite test
                , tasty-quickcheck
                , tagged
                , transformers >= 0.3
-               , quickcheck-classes >= 0.4.6
+               , quickcheck-classes >= 0.4.8
   ghc-options: -O2
 
 source-repository head

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -36,7 +36,7 @@ test-suite test
                , tasty-quickcheck
                , tagged
                , transformers >= 0.3
-               , quickcheck-classes >= 0.4.4
+               , quickcheck-classes >= 0.4.5
   ghc-options: -O2
 
 source-repository head

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -36,7 +36,7 @@ test-suite test
                , tasty-quickcheck
                , tagged
                , transformers >= 0.3
-               , quickcheck-classes >= 0.4.5
+               , quickcheck-classes >= 0.4.6
   ghc-options: -O2
 
 source-repository head

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -36,7 +36,7 @@ test-suite test
                , tasty-quickcheck
                , tagged
                , transformers >= 0.3
-               , quickcheck-classes >= 0.4.8
+               , quickcheck-classes >= 0.4.9
   ghc-options: -O2
 
 source-repository head


### PR DESCRIPTION
This was original requested in https://github.com/haskell/primitive/issues/58 and was received positively. Indeed, it appears that at three different authors have built nearly the same thing in the wild. This feature was implemented as a part of the larger and more ambitious https://github.com/haskell/primitive/pull/64, which eventually stalled. As @treeowl [commented](https://github.com/haskell/primitive/pull/64):

> This pull request is very large. Lots of new functionality. I suspect it might be better to break it up.

This is an attempt at precisely that. All that is implemented here is `PrimArray`. Discussion of design choices:

- In this PR, `PrimArray` is implemented as a data type on top of `ByteArray#`, not as a newtype on top of `ByteArray`. This makes some of the `Monoid` and `Semigroup` functions allocate a little more than they might otherwise (using `coerce` to sidestep the allocations). I don't think this matters though, since using `mconcat` on a `ByteArray`/`PrimArray` is an indication that you already built your array suboptimally.
- The type variable associated with a `PrimArray` should probably have a nominal role. (so maybe the `coerce` trick for newtypes couldn't actually work)
- There are functions for copying between `PrimArray` and `Ptr`. We have the analogy: `PrimArray` is to `Ptr` as `ByteArray` is to `Addr`.
- The `Eq` instance is intentionally the slow element-by-element comparison. It doesn't use `memcmp` under the hood because someone may want to define a type whose `Eq` instance evaluate values with different in-memory representations as equivalent. (ie- modular arithmetic)
- We get to have a much nicer `FromList` instance than `ByteArray`.