### PR TITLE
Data.Primitive.Ptr

### DIFF
--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- |
+-- Module      : Data.Primitive.Ptr
+-- Copyright   : (c) Roman Leshchinskiy 2009-2012
+-- License     : BSD-style
+--
+-- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
+-- Portability : non-portable
+--
+-- Primitive operations on machine addresses
+--
+
+module Data.Primitive.Ptr (
+  -- * Types
+  Ptr(..),
+
+  -- * Address arithmetic
+  nullPtr, advancePtr,
+
+  -- * Element access
+  indexOffPtr, readOffPtr, writeOffPtr,
+
+  -- * Block operations
+  copyPtr, movePtr, setPtr
+) where
+
+import Control.Monad.Primitive
+import Data.Primitive.Types
+
+import GHC.Base ( Int(..) )
+import GHC.Prim
+
+import GHC.Ptr
+import Foreign.Marshal.Utils
+
+
+-- | Offset a pointer by the given number of elements.
+advancePtr :: forall a. Prim a => Ptr a -> Int -> Ptr a
+advancePtr (Ptr a#) (I# i#) = Ptr (plusAddr# a# (i# *# sizeOf# (undefined :: a)))
+
+-- | Read a value from a memory position given by a pointer and an offset.
+-- The memory block the address refers to must be immutable. The offset is in
+-- elements of type @a@ rather than in bytes.
+indexOffPtr :: Prim a => Ptr a -> Int -> a
+{-# INLINE indexOffPtr #-}
+indexOffPtr (Ptr addr#) (I# i#) = indexOffAddr# addr# i#
+
+-- | Read a value from a memory position given by an address and an offset.
+-- The offset is in elements of type @a@ rather than in bytes.
+readOffPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> m a
+{-# INLINE readOffPtr #-}
+readOffPtr (Ptr addr#) (I# i#) = primitive (readOffAddr# addr# i#)
+
+-- | Write a value to a memory position given by an address and an offset.
+-- The offset is in elements of type @a@ rather than in bytes.
+writeOffPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> a -> m ()
+{-# INLINE writeOffPtr #-}
+writeOffPtr (Ptr addr#) (I# i#) x = primitive_ (writeOffAddr# addr# i# x)
+
+-- | Copy the given number of bytes from the second 'Ptr to the first. The
+-- areas may not overlap.
+copyPtr :: PrimMonad m
+  => Ptr a -- ^ destination pointer
+  -> Ptr a -- ^ source pointer
+  -> Int -- ^ number of elements
+  -> m ()
+{-# INLINE copyPtr #-}
+copyPtr (Ptr dst#) (Ptr src#) n
+  = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) n
+
+-- | Copy the given number of bytes from the second 'Ptr to the first. The
+-- areas may overlap.
+movePtr :: PrimMonad m
+  => Ptr a -- ^ destination address
+  -> Ptr a -- ^ source address
+  -> Int -- ^ number of elements
+  -> m ()
+{-# INLINE movePtr #-}
+movePtr (Ptr dst#) (Ptr src#) n
+  = unsafePrimToPrim $ moveBytes (Ptr dst#) (Ptr src#) n
+
+-- | Fill a memory block of with the given value. The length is in
+-- elements of type @a@ rather than in bytes.
+setPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> a -> m ()
+{-# INLINE setPtr #-}
+setPtr (Ptr addr#) (I# n#) x = primitive_ (setOffAddr# addr# 0# n# x)
+
+

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -18,7 +18,7 @@ module Data.Primitive.Ptr (
   Ptr(..),
 
   -- * Address arithmetic
-  nullPtr, advancePtr,
+  nullPtr, advancePtr, subtractPtr,
 
   -- * Element access
   indexOffPtr, readOffPtr, writeOffPtr,
@@ -39,7 +39,15 @@ import Foreign.Marshal.Utils
 
 -- | Offset a pointer by the given number of elements.
 advancePtr :: forall a. Prim a => Ptr a -> Int -> Ptr a
+{-# INLINE advancePtr #-}
 advancePtr (Ptr a#) (I# i#) = Ptr (plusAddr# a# (i# *# sizeOf# (undefined :: a)))
+
+-- | Subtract a pointer from another pointer. The result represents
+--   the number of elements of type @a@ that fit in the contiguous
+--   memory range bounded by these two pointers.
+subtractPtr :: forall a. Prim a => Ptr a -> Ptr a -> Int
+{-# INLINE subtractPtr #-}
+subtractPtr (Ptr a#) (Ptr b#) = I# (quotInt# (minusAddr# a# b#) (sizeOf# (undefined :: a)))
 
 -- | Read a value from a memory position given by a pointer and an offset.
 -- The memory block the address refers to must be immutable. The offset is in

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -68,7 +68,7 @@ writeOffPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> a -> m ()
 {-# INLINE writeOffPtr #-}
 writeOffPtr (Ptr addr#) (I# i#) x = primitive_ (writeOffAddr# addr# i# x)
 
--- | Copy the given number of bytes from the second 'Ptr' to the first. The
+-- | Copy the given number of elements from the second 'Ptr' to the first. The
 -- areas may not overlap.
 copyPtr :: forall m a. (PrimMonad m, Prim a)
   => Ptr a -- ^ destination pointer

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -77,20 +77,20 @@ copyPtr :: PrimMonad m
   -> m ()
 {-# INLINE copyPtr #-}
 copyPtr (Ptr dst#) (Ptr src#) n
-  = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) n
+  = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) (n * sizeOf (undefined :: a))
 
 -- | Copy the given number of bytes from the second 'Ptr to the first. The
 -- areas may overlap.
-movePtr :: PrimMonad m
+movePtr :: forall m a. PrimMonad m
   => Ptr a -- ^ destination address
   -> Ptr a -- ^ source address
   -> Int -- ^ number of elements
   -> m ()
 {-# INLINE movePtr #-}
 movePtr (Ptr dst#) (Ptr src#) n
-  = unsafePrimToPrim $ moveBytes (Ptr dst#) (Ptr src#) n
+  = unsafePrimToPrim $ moveBytes (Ptr dst#) (Ptr src#) (n * sizeOf (undefined :: a))
 
--- | Fill a memory block of with the given value. The length is in
+-- | Fill a memory block with the given value. The length is in
 -- elements of type @a@ rather than in bytes.
 setPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> a -> m ()
 {-# INLINE setPtr #-}

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -70,7 +70,7 @@ writeOffPtr (Ptr addr#) (I# i#) x = primitive_ (writeOffAddr# addr# i# x)
 
 -- | Copy the given number of bytes from the second 'Ptr to the first. The
 -- areas may not overlap.
-copyPtr :: PrimMonad m
+copyPtr :: forall m a. (PrimMonad m, Prim a)
   => Ptr a -- ^ destination pointer
   -> Ptr a -- ^ source pointer
   -> Int -- ^ number of elements
@@ -81,7 +81,7 @@ copyPtr (Ptr dst#) (Ptr src#) n
 
 -- | Copy the given number of bytes from the second 'Ptr to the first. The
 -- areas may overlap.
-movePtr :: forall m a. PrimMonad m
+movePtr :: forall m a. (PrimMonad m, Prim a)
   => Ptr a -- ^ destination address
   -> Ptr a -- ^ source address
   -> Int -- ^ number of elements

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -68,7 +68,7 @@ writeOffPtr :: (Prim a, PrimMonad m) => Ptr a -> Int -> a -> m ()
 {-# INLINE writeOffPtr #-}
 writeOffPtr (Ptr addr#) (I# i#) x = primitive_ (writeOffAddr# addr# i# x)
 
--- | Copy the given number of bytes from the second 'Ptr to the first. The
+-- | Copy the given number of bytes from the second 'Ptr' to the first. The
 -- areas may not overlap.
 copyPtr :: forall m a. (PrimMonad m, Prim a)
   => Ptr a -- ^ destination pointer
@@ -79,7 +79,7 @@ copyPtr :: forall m a. (PrimMonad m, Prim a)
 copyPtr (Ptr dst#) (Ptr src#) n
   = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) (n * sizeOf (undefined :: a))
 
--- | Copy the given number of bytes from the second 'Ptr to the first. The
+-- | Copy the given number of elements from the second 'Ptr' to the first. The
 -- areas may overlap.
 movePtr :: forall m a. (PrimMonad m, Prim a)
   => Ptr a -- ^ destination address

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@
 
  * Fix the broken `Functor`, `Applicative`, and `Monad` instances for
    `Array` and `SmallArray`.
+ 
+ * Implement `Data.Primitive.Ptr`, implementations of `Ptr` functions
+   that require a `Prim` constraint instead of a `Storable` constraint.
 
 ## Changes in version 0.6.3.0
 

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -44,6 +44,7 @@ Library
         Data.Primitive.SmallArray
         Data.Primitive.UnliftedArray
         Data.Primitive.Addr
+        Data.Primitive.Ptr
         Data.Primitive.MutVar
 
   Other-Modules:


### PR DESCRIPTION
This PR provides functions for working with `Ptr` that take a `Prim` constraint instead of a `Storable` constraint. My motivation for this is that at work, I've ended up in situations where I've got a `Ptr` and a `MutableByteArray` referring to elements of the same type. It's weird to carry around both the `Storable` constraint and the `Prim` constraint in these situations especially because the two instances always agree with one another. To avoid the `Storable` constraint, I usually end up casting the `Ptr` to an `Addr`. This is boilerplate I would like to avoid, and it makes the whole process a little more error-prone.

Questions:

- Do other people think this is a good idea?
- Should these functions operate in `PrimMonad`, or should these be constrained to `IO`?