### PR TITLE
Add benchmark suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ install:
       cabal new-update head.hackage -v
     fi
   - grep -Ev -- '^\s*--' ${HOME}/.cabal/config | grep -Ev '^\s*$'
-  - "printf 'packages: \".\" \"./test\"\\n' > cabal.project"
+  - "printf 'packages: \".\" \"./test\" \"./bench\"\\n' > cabal.project"
   - echo 'package quickcheck-classes' >> cabal.project
   - "echo '  flags: -aeson -semigroupoids' >> cabal.project"
   - cat cabal.project
@@ -103,8 +103,11 @@ install:
   - if [ -f "./test/configure.ac" ]; then
       (cd "./test" && autoreconf -i);
     fi
+  - if [ -f "./bench/configure.ac" ]; then
+      (cd "./bench" && autoreconf -i);
+    fi
   - rm -f cabal.project.freeze
-  - rm -rf .ghc.environment.* "."/dist "./test"/dist
+  - rm -rf .ghc.environment.* "."/dist "./test"/dist "./bench"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;
@@ -113,10 +116,11 @@ script:
   # test that source-distributions can be generated
   - (cd "." && cabal sdist)
   - (cd "./test" && cabal sdist)
-  - mv "."/dist/primitive-*.tar.gz "./test"/dist/primitive-tests-*.tar.gz ${DISTDIR}/
+  - (cd "./bench" && cabal sdist)
+  - mv "."/dist/primitive-*.tar.gz "./test"/dist/primitive-tests-*.tar.gz "./bench"/dist/primitive-benchmarks-*.tar.gz ${DISTDIR}/
   - cd ${DISTDIR} || false
   - find . -maxdepth 1 -name '*.tar.gz' -exec tar -xvf '{}' \;
-  - "printf 'packages: primitive-*/*.cabal primitive-tests-*/*.cabal\\n' > cabal.project"
+  - "printf 'packages: primitive-*/*.cabal primitive-tests-*/*.cabal primitive-benchmarks-*/*.cabal\\n' > cabal.project"
   - echo 'package quickcheck-classes' >> cabal.project
   - "echo '  flags: -aeson -semigroupoids' >> cabal.project"
   - cat cabal.project
@@ -134,6 +138,7 @@ script:
   #   Commented out due to https://github.com/haskell/cabal/issues/4551
   # - (cd primitive-* && cabal check)
   - (cd primitive-tests-* && cabal check)
+  - (cd primitive-benchmarks-* && cabal check)
 
   # haddock
   - rm -rf ./dist-newstyle

--- a/bench/Array/Traverse/Closure.hs
+++ b/bench/Array/Traverse/Closure.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE MagicHash #-}
+
+module Array.Traverse.Closure
+  ( traversePoly
+  ) where
+
+import Control.Applicative
+import Control.Monad.ST
+import Data.Primitive.Array
+import GHC.Exts (indexArray#,Int(..),MutableArray#)
+
+{-# INLINE traversePoly #-}
+traversePoly
+  :: Applicative f
+  => (a -> f b)
+  -> Array a
+  -> f (Array b)
+traversePoly f = \ !ary ->
+  let
+    !len = sizeofArray ary
+    go !i
+      | i == len = pure $ STA $ \mary -> unsafeFreezeArray (MutableArray mary)
+      | (# x #) <- indexArray## ary i
+      = liftA2 (\b (STA m) -> STA $ \mary ->
+                  writeArray (MutableArray mary) i b >> m mary)
+               (f x) (go (i + 1))
+  in if len == 0
+     then pure mempty
+     else runSTA len <$> go 0
+
+badTraverseValue :: a
+badTraverseValue = die "traversePoly" "bad indexing"
+{-# NOINLINE badTraverseValue #-}
+
+die :: String -> String -> a
+die fun problem = error $ "Array.Traverse.Closure" ++ fun ++ ": " ++ problem
+
+newtype STA a = STA {_runSTA :: forall s. MutableArray# s a -> ST s (Array a)}
+
+runSTA :: Int -> STA a -> Array a
+runSTA !sz = \ (STA m) -> runST $ newArray_ sz >>= \ ar -> m (marray# ar)
+{-# INLINE runSTA #-}
+
+newArray_ :: Int -> ST s (MutableArray s a)
+newArray_ !n = newArray n badTraverseValue
+
+indexArray## :: Array a -> Int -> (# a #)
+indexArray## arr (I# i) = indexArray# (array# arr) i
+{-# INLINE indexArray## #-}

--- a/bench/Array/Traverse/Compose.hs
+++ b/bench/Array/Traverse/Compose.hs
@@ -1,0 +1,47 @@
+module Array.Traverse.Compose
+  ( traversePoly
+  , traverseMono
+  ) where
+
+import Data.Functor.Compose
+import Data.Primitive.Array
+
+{-# INLINE traversePoly #-}
+traversePoly
+  :: Applicative f
+  => (a -> f b)
+  -> Array a
+  -> f (Array b)
+traversePoly f ary = runST $ do
+  let !sz = sizeofArray ary
+  mary <- newArray sz
+  let go !i = do
+        
+    !len = sizeofArray ary
+    go !i
+      | i == len = pure $ STA $ \mary -> unsafeFreezeArray (MutableArray mary)
+      | (# x #) <- indexArray## ary i
+      = liftA2 (\b (STA m) -> STA $ \mary ->
+                  writeArray (MutableArray mary) i b >> m mary)
+               (f x) (go (i + 1))
+  in if len == 0
+     then pure emptyArray
+     else runSTA len <$> go 0
+
+badTraverseValue :: a
+badTraverseValue = die "traversePoly" "bad indexing"
+{-# NOINLINE badTraverseValue #-}
+
+die :: String -> String -> a
+die fun problem = error $ "Array.Traverse.Closure" ++ fun ++ ": " ++ problem
+
+newtype STA a = STA {_runSTA :: forall s. MutableArray# s a -> ST s (Array a)}
+
+runSTA :: Int -> STA a -> Array a
+runSTA !sz = \ (STA m) -> runST $ newArray_ sz >>= \ ar -> m (marray# ar)
+{-# INLINE runSTA #-}
+
+newArray_ :: Int -> ST s (MutableArray s a)
+newArray_ !n = newArray n badTraverseValue
+
+

--- a/bench/Array/Traverse/Unsafe.hs
+++ b/bench/Array/Traverse/Unsafe.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Array.Traverse.Unsafe
+  ( traversePoly
+  , traverseMono
+  ) where
+
+import Control.Monad.ST
+import Control.Monad.Trans.State.Strict
+import Control.Monad.Primitive
+import Data.Primitive.Array
+
+{-# INLINE traversePoly #-}
+traversePoly
+  :: PrimMonad m
+  => (a -> m b)
+  -> Array a
+  -> m (Array b)
+traversePoly f = \ !ary ->
+  let
+    !sz = sizeofArray ary
+    go !i !mary
+      | i == sz
+      = unsafeFreezeArray mary
+      | otherwise
+      = do
+          a <- indexArrayM ary i
+          b <- f a
+          writeArray mary i b
+          go (i + 1) mary
+  in do
+    mary <- newArray sz badTraverseValue
+    go 0 mary
+
+badTraverseValue :: a
+badTraverseValue = die "traversePoly" "bad indexing"
+{-# NOINLINE badTraverseValue #-}
+
+die :: String -> String -> a
+die fun problem = error $ "Array.Traverse.Unsafe" ++ fun ++ ": " ++ problem
+
+-- Included to make it easy to inspect GHC Core that results
+-- from inlining traversePoly.
+traverseMono :: 
+     (Int -> StateT Word (ST s) Int)
+  -> Array Int
+  -> StateT Word (ST s) (Array Int)
+traverseMono f x = traversePoly f x

--- a/bench/ByteArray/Compare.hs
+++ b/bench/ByteArray/Compare.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ByteArray.Compare
+  ( benchmark
+  , argumentSmall
+  , argumentMedium
+  , argumentLarge
+  ) where
+
+import Data.Primitive
+import Data.Primitive.UnliftedArray
+import Data.Word
+import Control.Monad
+import Control.Monad.ST (runST)
+import GHC.Exts (fromList)
+
+-- This takes the cross product of the argument with itself
+-- and compares each pair of combined ByteArrays. In other words,
+-- it compare every ByteArray to every other ByteArray (including
+-- itself). This is does efficiently and should not allocate
+-- any memory.
+benchmark :: UnliftedArray ByteArray -> Int
+benchmark !uarr = outer 0
+  where
+  sz = sizeofUnliftedArray uarr
+  outer :: Int -> Int
+  outer !v0 =
+    let go !v !ix = if ix < sz
+          then go (inner v (indexUnliftedArray uarr ix)) (ix + 1)
+          else v
+     in go v0 0
+  inner :: Int -> ByteArray -> Int
+  inner !v0 !barr =
+    let go !v !ix = if ix < sz
+          then
+            let !y = case compare barr (indexUnliftedArray uarr ix) of
+                  LT -> (-1)
+                  EQ -> 0
+                  GT -> 1
+             in go (v + y) (ix + 1)
+          else v
+     in go v0 0
+
+-- This is an array of all byte arrays consistent of the bytes 0 and 1
+-- bewteen length 0 and 7 inclusive:
+--
+-- []
+-- [0]
+-- [1]
+-- [0,0]
+-- [0,1]
+-- ...
+-- [1,1,1,1,1,1,0]
+-- [1,1,1,1,1,1,1]
+--
+-- These are very small byte arrays. All of them are smaller than a
+-- cache line. A comparison function that uses the FFI may perform
+-- worse on such inputs than one that does not.
+argumentSmall :: UnliftedArray ByteArray
+argumentSmall = runST $ do
+  let (ys :: [[Word8]]) = foldMap (\n -> replicateM n [0,1]) (enumFromTo 0 7)
+  marr <- unsafeNewUnliftedArray (length ys)
+  let go !_ [] = return ()
+      go !ix (x : xs) = do
+        writeUnliftedArray marr ix (fromList x)
+        go (ix + 1) xs
+  go 0 ys
+  unsafeFreezeUnliftedArray marr
+
+
+-- This is an array of all byte arrays consistent of the bytes 0 and 1
+-- bewteen length 0 and 7 inclusive. However, they are all padded on the
+-- left by the same 256 bytes. Comparing any two of them will require
+-- walking and comparing the first 256 bytes.
+argumentMedium :: UnliftedArray ByteArray
+argumentMedium  = runST $ do
+  let (ys :: [[Word8]]) = foldMap (\n -> map (enumFromTo 0 255 ++) (replicateM n [0,1])) (enumFromTo 0 7)
+  marr <- unsafeNewUnliftedArray (length ys)
+  let go !_ [] = return ()
+      go !ix (x : xs) = do
+        writeUnliftedArray marr ix (fromList x)
+        go (ix + 1) xs
+  go 0 ys
+  unsafeFreezeUnliftedArray marr
+
+-- Same thing but with left padding of 1024 bytes.
+argumentLarge :: UnliftedArray ByteArray
+argumentLarge  = runST $ do
+  let (ys :: [[Word8]]) = foldMap (\n -> map (concat (replicate 4 (enumFromTo 0 255)) ++) (replicateM n [0,1])) (enumFromTo 0 7)
+  marr <- unsafeNewUnliftedArray (length ys)
+  let go !_ [] = return ()
+      go !ix (x : xs) = do
+        writeUnliftedArray marr ix (fromList x)
+        go (ix + 1) xs
+  go 0 ys
+  unsafeFreezeUnliftedArray marr

--- a/bench/LICENSE
+++ b/bench/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2008-2009, Roman Leshchinskiy
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+ 
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+ 
+- Neither name of the University nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE UNIVERSITY COURT OF THE UNIVERSITY OF
+GLASGOW AND THE CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+UNIVERSITY COURT OF THE UNIVERSITY OF GLASGOW OR THE CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,7 @@
+Benchmark Suite
+=======================
+
+The benchmark suite for `primitive` cannot be included in the same package
+as `primitive` itself. The benchmark suite depends on `gauge`, which
+transitively depends on `primitive`. To break up this dependency cycle,
+the test suite lives here in its own unpublished package.

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -20,15 +20,34 @@ import Data.Proxy (Proxy(..))
 import Control.DeepSeq
 import Control.Monad.Trans.State.Strict
 
+-- These are fixed implementations of certain operations. In the event
+-- that primitive changes its implementation of a function, these
+-- implementations stay the same. They are helpful for ensuring that
+-- something that is a performance win in one version of GHC doesn't
+-- become a regression later. They are also helpful for evaluating
+-- how well different implementation hold up in different scenarios.
 import qualified Array.Traverse.Unsafe
 import qualified Array.Traverse.Closure
+
+-- These are particular scenarios that are tested against the
+-- implementations actually used by primitive.
+import qualified ByteArray.Compare
 
 main :: IO ()
 main = defaultMain
   [ bgroup "Array"
-    [ bgroup "traverse"
-      [ bench "closure" (nf (\x -> runST (runStateT (Array.Traverse.Closure.traversePoly cheap x) 0)) numbers)
-      , bench "unsafe" (nf (\x -> runST (runStateT (Array.Traverse.Unsafe.traversePoly cheap x) 0)) numbers)
+    [ bgroup "implementations"
+      [ bgroup "traverse"
+        [ bench "closure" (nf (\x -> runST (runStateT (Array.Traverse.Closure.traversePoly cheap x) 0)) numbers)
+        , bench "unsafe" (nf (\x -> runST (runStateT (Array.Traverse.Unsafe.traversePoly cheap x) 0)) numbers)
+        ]
+      ]
+    ]
+  , bgroup "ByteArray"
+    [ bgroup "compare"
+      [ bench "small" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentSmall)
+      , bench "medium" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentMedium)
+      , bench "large" (whnf ByteArray.Compare.benchmark ByteArray.Compare.argumentLarge)
       ]
     ]
   ]

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+import Gauge
+import Control.Applicative
+import Control.Monad
+import Control.Monad.Primitive
+import Control.Monad.ST
+import Data.Monoid
+import Data.Primitive
+import Data.Primitive.Array
+import Data.Primitive.ByteArray
+import Data.Primitive.Types
+import Data.Primitive.SmallArray
+import Data.Word
+import Data.Proxy (Proxy(..))
+import Control.DeepSeq
+import Control.Monad.Trans.State.Strict
+
+import qualified Array.Traverse.Unsafe
+import qualified Array.Traverse.Closure
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "Array"
+    [ bgroup "traverse"
+      [ bench "closure" (nf (\x -> runST (runStateT (Array.Traverse.Closure.traversePoly cheap x) 0)) numbers)
+      , bench "unsafe" (nf (\x -> runST (runStateT (Array.Traverse.Unsafe.traversePoly cheap x) 0)) numbers)
+      ]
+    ]
+  ]
+
+cheap :: Int -> StateT Int (ST s) Int
+cheap i = modify (\x -> x + i) >> return (i * i)
+
+numbers :: Array Int
+numbers = fromList (enumFromTo 0 10000)
+
+instance NFData a => NFData (Array a) where
+  rnf ary = go 0 where
+    !sz = sizeofArray ary
+    go !ix = if ix < sz
+      then ()
+      else rnf (indexArray ary ix) `seq` go (ix + 1)

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -25,6 +25,7 @@ Tested-With:
 
 flag primitive-benchmarks
   default: True
+  manual: True
 
 benchmark bench
   if !flag(primitive-benchmarks)
@@ -38,6 +39,7 @@ benchmark bench
   other-modules:
     Array.Traverse.Closure
     Array.Traverse.Unsafe
+    ByteArray.Compare
   build-depends:
       base >= 4.8 && < 4.12
     , primitive

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -23,7 +23,13 @@ Tested-With:
   GHC == 8.2.2,
   GHC == 8.4.1
 
+flag primitive-benchmarks
+  default: True
+
 benchmark bench
+  if !flag(primitive-benchmarks)
+    buildable: False
+
   Default-Language: Haskell2010
   hs-source-dirs: .
   main-is: main.hs
@@ -33,7 +39,7 @@ benchmark bench
     Array.Traverse.Closure
     Array.Traverse.Unsafe
   build-depends:
-      base >= 4.5 && < 4.12
+      base >= 4.8 && < 4.12
     , primitive
     , deepseq
     , ghc-prim
@@ -43,3 +49,4 @@ benchmark bench
 source-repository head
   type:     git
   location: https://github.com/haskell/primitive
+  subdir:   bench

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -25,7 +25,6 @@ Tested-With:
 
 flag primitive-benchmarks
   default: True
-  manual: True
 
 benchmark bench
   if !flag(primitive-benchmarks)

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -1,0 +1,45 @@
+Name:           primitive-benchmarks
+Version:        0.1
+License:        BSD3
+License-File:   LICENSE
+
+Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>
+Maintainer:     libraries@haskell.org
+Copyright:      (c) Roman Leshchinskiy 2009-2012
+Homepage:       https://github.com/haskell/primitive
+Bug-Reports:    https://github.com/haskell/primitive/issues
+Category:       Data
+Synopsis:       primitive benchmarks
+Cabal-Version:  >= 1.10
+Build-Type:     Simple
+Description:    @primitive@ benchmarks
+
+Tested-With:
+  GHC == 7.4.2,
+  GHC == 7.6.3,
+  GHC == 7.8.4,
+  GHC == 7.10.3,
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.1
+
+benchmark bench
+  Default-Language: Haskell2010
+  hs-source-dirs: .
+  main-is: main.hs
+  type: exitcode-stdio-1.0
+  ghc-options: -O2
+  other-modules:
+    Array.Traverse.Closure
+    Array.Traverse.Unsafe
+  build-depends:
+      base >= 4.5 && < 4.12
+    , primitive
+    , deepseq
+    , ghc-prim
+    , gauge
+    , transformers >= 0.3
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/primitive

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages: .
           ./test
+          ./bench
 package quickcheck-classes
   flags: -aeson -semigroupoids
   

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -36,7 +36,7 @@ test-suite test
                , tasty-quickcheck
                , tagged
                , transformers >= 0.3
-               , quickcheck-classes >= 0.4.4
+               , quickcheck-classes >= 0.4.8
   ghc-options: -O2
 
 source-repository head

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -42,3 +42,4 @@ test-suite test
 source-repository head
   type:     git
   location: https://github.com/haskell/primitive
+  subdir:   test


### PR DESCRIPTION
Benchmark performance difference between closure-building array traversal and the unsafe PrimMonad variant. Currently, `cabal new-build` fails to build this if you are using GHC 8.0 or newer because of something going on in `basement` (which `gauge` depends on). I'm sure this will be resolved soon. For now, we can do:

```
$ cabal new-build bench --enable-benchmarks -w ghc-7.10.3
$ ./dist-newstyle/build/x86_64-linux/ghc-7.10.3/primitive-benchmarks-0.1/c/bench/build/bench/bench
benchmarked Array/traverse/closure
time                 929.5 μs   (913.6 μs .. 948.6 μs)
                     0.998 R²   (0.998 R² .. 0.999 R²)
mean                 910.4 μs   (906.5 μs .. 916.2 μs)
std dev              15.65 μs   (10.99 μs .. 20.36 μs)

benchmarked Array/traverse/unsafe
time                 360.6 μs   (357.1 μs .. 363.8 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 354.3 μs   (353.1 μs .. 355.6 μs)
std dev              4.406 μs   (3.300 μs .. 6.144 μs)
```

This helps confirm the suspicion that the unsafe variant is actually faster. I've measured these two functions by copying their implementations into the benchmarks directory. For benchmarking multiple possible implementations of the same thing, I prefer copying code into the benchmark suite like this. In the event that we ever change the implementation of `traverse`, we will still be able to measure it against the other options.