### PR TITLE
Use compareByteArrays#

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -24,6 +24,9 @@ module Data.Primitive.ByteArray (
   -- * Element access
   readByteArray, writeByteArray, indexByteArray,
 
+  -- * Constructing
+  byteArrayFromList, byteArrayFromListN,
+
   -- * Folding
   foldrByteArray,
 
@@ -63,7 +66,6 @@ import Data.Typeable ( Typeable )
 import Data.Data ( Data(..) )
 import Data.Primitive.Internal.Compat ( isTrue#, mkNoRepType )
 import Numeric
-import System.IO.Unsafe
 
 #if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as SG
@@ -72,6 +74,12 @@ import qualified Data.Foldable as F
 
 #if !(MIN_VERSION_base(4,8,0))
 import Data.Monoid (Monoid(..))
+#endif
+
+#if __GLASGOW_HASKELL__ >= 804
+import GHC.Exts (compareByteArrays#)
+#else
+import System.IO.Unsafe (unsafeDupablePerformIO)
 #endif
 
 -- | Byte arrays
@@ -223,17 +231,20 @@ foldrByteArray f z arr = go 0
       | otherwise                    = z
     sz = sizeOf (undefined :: a)
 
-fromListN :: Prim a => Int -> [a] -> ByteArray
-fromListN n ys = runST $ do
+byteArrayFromList :: Prim a => [a] -> ByteArray
+byteArrayFromList xs = byteArrayFromListN (length xs) xs
+
+byteArrayFromListN :: Prim a => Int -> [a] -> ByteArray
+byteArrayFromListN n ys = runST $ do
     marr <- newByteArray (n * sizeOf (head ys))
     let go !ix [] = if ix == n
           then return ()
-          else die "fromListN" "list length less than specified size"
+          else die "byteArrayFromListN" "list length less than specified size"
         go !ix (x : xs) = if ix < n
           then do
             writeByteArray marr ix x
             go (ix + 1) xs
-          else die "fromListN" "list length greater than specified size"
+          else die "byteArrayFromListN" "list length greater than specified size"
     go 0 ys
     unsafeFreezeByteArray marr
 
@@ -366,8 +377,24 @@ instance Show ByteArray where
           comma | i == 0    = id
                 | otherwise = showString ", "
 
+
+compareByteArrays :: ByteArray -> ByteArray -> Int -> Ordering
+{-# INLINE compareByteArrays #-}
+#if __GLASGOW_HASKELL__ >= 804
+compareByteArrays (ByteArray ba1#) (ByteArray ba2#) (I# n#) =
+  compare (I# (compareByteArrays# ba1# 0# ba2# 0# n#)) 0
+#else
+-- Emulate GHC 8.4's 'GHC.Prim.compareByteArrays#'
+compareByteArrays (ByteArray ba1#) (ByteArray ba2#) (I# n#)
+    = compare (fromCInt (unsafeDupablePerformIO (memcmp_ba ba1# ba2# n))) 0
+  where
+    n = fromIntegral (I# n#) :: CSize
+    fromCInt = fromIntegral :: CInt -> Int
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memcmp"
   memcmp_ba :: ByteArray# -> ByteArray# -> CSize -> IO CInt
+#endif
+
 
 sameByteArray :: ByteArray# -> ByteArray# -> Bool
 sameByteArray ba1 ba2 =
@@ -381,22 +408,24 @@ sameByteArray ba1 ba2 =
 
 instance Eq ByteArray where
   ba1@(ByteArray ba1#) == ba2@(ByteArray ba2#)
-    | sameByteArray ba1# ba2#                    = True
-    | sizeofByteArray ba1 /= sizeofByteArray ba2 = False
-    | otherwise =
-        case unsafeDupablePerformIO $ memcmp_ba ba1# ba2# (fromIntegral $ sizeofByteArray ba1) of
-          0 -> True
-          _ -> False
+    | sameByteArray ba1# ba2# = True
+    | n1 /= n2 = False
+    | otherwise = compareByteArrays ba1 ba2 n1 == EQ
+    where
+      n1 = sizeofByteArray ba1
+      n2 = sizeofByteArray ba2
 
+-- Note: On GHC 8.4, the primop compareByteArrays# performs a check for pointer
+-- equality as a shortcut, so the check here is actually redundant. However, it
+-- is included here because it is likely better to check for pointer equality
+-- before checking for length equality. Getting the length requires deferencing
+-- the pointers, which could cause accesses to memory that is not in the cache.
+-- By contrast, a pointer equality check is always extremely cheap.
 instance Ord ByteArray where
   ba1@(ByteArray ba1#) `compare` ba2@(ByteArray ba2#)
     | sameByteArray ba1# ba2# = EQ
-    | n1 /= n2                = n1 `compare` n2
-    | otherwise =
-        case unsafeDupablePerformIO $ memcmp_ba ba1# ba2# (fromIntegral n1) of
-          x | x >  0 -> GT
-            | x == 0 -> EQ
-            | otherwise -> LT
+    | n1 /= n2 = n1 `compare` n2
+    | otherwise = compareByteArrays ba1 ba2 n1
     where
       n1 = sizeofByteArray ba1
       n2 = sizeofByteArray ba2
@@ -462,8 +491,8 @@ instance Exts.IsList ByteArray where
   type Item ByteArray = Word8
 
   toList = foldrByteArray (:) []
-  fromList xs = fromListN (length xs) xs
-  fromListN = fromListN
+  fromList xs = byteArrayFromListN (length xs) xs
+  fromListN = byteArrayFromListN
 #endif
 
 die :: String -> String -> a

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
  * Fix the broken `Functor`, `Applicative`, and `Monad` instances for
    `Array` and `SmallArray`.
 
+ * Use `compareByteArrays#` for the `Eq` and `Ord` instances of
+   `ByteArray` when building with GHC 8.4 and newer.
+
 ## Changes in version 0.6.3.0
 
  * Add `PrimMonad` instances for `ContT`, `AccumT`, and `SelectT` from

--- a/test/main.hs
+++ b/test/main.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 import Control.Applicative
 import Control.Monad
@@ -25,7 +26,7 @@ import Data.Semigroup (stimes)
 #endif
 
 import Test.Tasty (defaultMain,testGroup,TestTree)
-import Test.QuickCheck (Arbitrary,Arbitrary1,Gen)
+import Test.QuickCheck (Arbitrary,Arbitrary1,Gen,(===))
 import qualified Test.Tasty.QuickCheck as TQC
 import qualified Test.QuickCheck as QC
 import qualified Test.QuickCheck.Classes as QCC
@@ -69,7 +70,11 @@ main = do
 #endif
       ]
     , testGroup "ByteArray"
-      [ lawsToTest (QCC.eqLaws (Proxy :: Proxy ByteArray))
+      [ testGroup "Ordering"
+        [ TQC.testProperty "equality" byteArrayEqProp
+        , TQC.testProperty "compare" byteArrayCompareProp
+        ]
+      , lawsToTest (QCC.eqLaws (Proxy :: Proxy ByteArray))
       , lawsToTest (QCC.ordLaws (Proxy :: Proxy ByteArray))
       , lawsToTest (QCC.showReadLaws (Proxy :: Proxy (Array Int)))
 #if MIN_VERSION_base(4,7,0)
@@ -77,6 +82,20 @@ main = do
 #endif
       ]
     ]
+
+byteArrayCompareProp :: QC.Property
+byteArrayCompareProp = QC.property $ \(xs :: [Word8]) (ys :: [Word8]) ->
+  compareLengthFirst xs ys === compare (byteArrayFromList xs) (byteArrayFromList ys)
+
+byteArrayEqProp :: QC.Property
+byteArrayEqProp = QC.property $ \(xs :: [Word8]) (ys :: [Word8]) ->
+  (compareLengthFirst xs ys == EQ) === (byteArrayFromList xs == byteArrayFromList ys)
+
+compareLengthFirst :: [Word8] -> [Word8] -> Ordering
+compareLengthFirst xs ys = case compare (length xs) (length ys) of
+  LT -> LT
+  GT -> GT
+  EQ -> compare xs ys
 
 -- on GHC 7.4, Proxy is not polykinded, so we need this instead.
 data Proxy1 (f :: * -> *) = Proxy1


### PR DESCRIPTION
Resolves https://github.com/haskell/primitive/issues/107

Use compareByteArrays`  for the Eq and Ord instance of ByteArray when building with GHC 8.4 or newer. Add tests to ensure that the behavior of the Eq and Ord instances are consistent across different versions of GHC. Additionally, export byteArrayFromList and byteArrayFromListN, which are helpful for making the test suite backwards-compatible.

Hold off on merging this until I get the benchmark suite in better shape. I want to ensure that this doesn't somehow introduce a performance regression.