### PR TITLE
reexport SmallArray and UnliftedArray types and functions from Data.Primitive

### DIFF
--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -25,3 +25,5 @@ import Data.Primitive.Types
 import Data.Primitive.Array
 import Data.Primitive.ByteArray
 import Data.Primitive.Addr
+import Data.Primitive.SmallArray
+import Data.Primitive.UnliftedArray

--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -15,6 +15,8 @@ module Data.Primitive (
   module Data.Primitive.Array,
   module Data.Primitive.ByteArray,
   module Data.Primitive.Addr,
+  module Data.Primitive.SmallArray,
+  module Data.Primitive.UnliftedArray,
 
   sizeOf, alignment
 ) where

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,9 @@
  * Add `Prim` instances for lots of types in `Foreign.C.Types` and
    `System.Posix.Types`.
 
+ * Reexport `Data.Primitive.SmallArray` and `Data.Primitive.UnliftedArray`
+   from `Data.Primitive`.
+
 ## Changes in version 0.6.3.0
 
  * Add `PrimMonad` instances for `ContT`, `AccumT`, and `SelectT` from


### PR DESCRIPTION
resolves https://github.com/haskell/primitive/issues/125