### PR TITLE
eliminate needless reexport of sizeOf and alignment from Data.Primitive

### DIFF
--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -18,9 +18,7 @@ module Data.Primitive (
   module Data.Primitive.Addr,
   module Data.Primitive.SmallArray,
   module Data.Primitive.UnliftedArray,
-  module Data.Primitive.PrimArray,
-
-  sizeOf, alignment
+  module Data.Primitive.PrimArray
   -- * Naming Conventions
   -- $namingConventions
 ) where


### PR DESCRIPTION
This has been bothering me for a while.