### PR TITLE
add PrimMach typeclass and implement casPrimArray with it

### DIFF
--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -20,6 +20,7 @@
 
 module Data.Primitive.Types (
   Prim(..),
+  PrimMach(..),
   sizeOf, alignment,
 
   Addr(..),
@@ -134,6 +135,21 @@ sizeOf x = I# (sizeOf# x)
 -- | Alignment of values of type @a@. The argument is not used.
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
+
+-- | Class of types supporting primitive operations that are isomorphic to
+-- a machine integer. Such types support compare-and-swap and other atomic
+-- operations.
+class Prim a => PrimMach a where
+  primMachToInt# :: a -> Int#
+  primMachFromInt# :: Int# -> a
+
+instance PrimMach Int where
+  primMachToInt# (I# i) = i
+  primMachFromInt# = I#
+
+instance PrimMach Word where
+  primMachToInt# (W# i) = word2Int# i
+  primMachFromInt# i = W# (int2Word# i)
 
 -- | Newtype that uses a 'Prim' instance to give rise to a 'Storable' instance.
 -- This type is intended to be used with the @DerivingVia@ extension available


### PR DESCRIPTION
This solution to wrapping the atomics primops is an alternative to https://github.com/haskell/primitive/pull/151 and is incompatible with it. This PR only wrap `casIntArray#`, but there are a number of other functions where this typeclass could be used:

- `atomicReadIntArray#`
- `atomicWriteIntArray#`
- `fetchAddIntArray#`
- `fetchSubIntArray#`
- `fetchAndIntArray#`
- `fetchNandIntArray#`
- `fetchOrIntArray#`
- `fetchXorIntArray#`

What this PR offers is a way to write a single `casPrimArray` function such that it will work on both `PrimArray Int` and `PrimArray Word` as well as any newtype wrapper over either of these two types. (It's worth noting that the `And`, `Nand`, `Or`, and `Xor` fetch functions would typically be used with `Word`). The drawback is that a new typeclass is need to accomplish this. I would appreciate any thoughts on this.