### PR TITLE
Add function for copying from Ptr to MutablePrimArray

### DIFF
--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -34,7 +34,9 @@ module Data.Primitive.Ptr (
 
 import Control.Monad.Primitive
 import Data.Primitive.Types
+#if __GLASGOW_HASKELL__ >= 708
 import Data.Primitive.PrimArray (MutablePrimArray(..))
+#endif
 
 import GHC.Base ( Int(..) )
 import GHC.Prim


### PR DESCRIPTION
I started compiling my stuff start currently uses `prim-array` against the master branch of `primitive`, and I realized that I had forgotten to implement `copyPtrToMutablePrimArray` in `Data.Primitive.Ptr`. This happened because I was working on the `PrimArray` module and the `Ptr` module in separate branches at the same time. Anyway, this PR provides the missing wrapper around `copyAddrToByteArray#`.