### PR TITLE
Document the lack of guarantees around Ord instances

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -379,6 +379,9 @@ arrayLiftCompare elemCompare a1 a2 = loop 0
     = elemCompare x1 x2 `mappend` loop (i+1)
     | otherwise = compare (sizeofArray a1) (sizeofArray a2)
 
+-- | __Note__: This library provides no guarantees about the particular ordering
+-- used. Users should not rely on it being the same as the ordering used for
+-- lists. It is subject to change between major versions.
 instance Ord a => Ord (Array a) where
   compare a1 a2 = arrayLiftCompare compare a1 a2
 

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -446,12 +446,9 @@ instance Eq ByteArray where
       n1 = sizeofByteArray ba1
       n2 = sizeofByteArray ba2
 
--- Note: On GHC 8.4, the primop compareByteArrays# performs a check for pointer
--- equality as a shortcut, so the check here is actually redundant. However, it
--- is included here because it is likely better to check for pointer equality
--- before checking for length equality. Getting the length requires deferencing
--- the pointers, which could cause accesses to memory that is not in the cache.
--- By contrast, a pointer equality check is always extremely cheap.
+-- | __Note__: This library provides no guarantees about the particular ordering
+-- used (lexicographic,alphabetical,etc.). Users should not rely on the ordering,
+-- as it may change between major versions.
 instance Ord ByteArray where
   ba1@(ByteArray ba1#) `compare` ba2@(ByteArray ba2#)
     | sameByteArray ba1# ba2# = EQ
@@ -460,6 +457,12 @@ instance Ord ByteArray where
     where
       n1 = sizeofByteArray ba1
       n2 = sizeofByteArray ba2
+-- Note: On GHC 8.4, the primop compareByteArrays# performs a check for pointer
+-- equality as a shortcut, so the check here is actually redundant. However, it
+-- is included here because it is likely better to check for pointer equality
+-- before checking for length equality. Getting the length requires deferencing
+-- the pointers, which could cause accesses to memory that is not in the cache.
+-- By contrast, a pointer equality check is always extremely cheap.
 
 appendByteArray :: ByteArray -> ByteArray -> ByteArray
 appendByteArray a b = runST $ do

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -157,9 +157,9 @@ instance (Eq a, Prim a) => Eq (PrimArray a) where
       | i < 0 = True
       | otherwise = indexPrimArray a1 i == indexPrimArray a2 i && loop (i-1)
 
--- | __Note__: For the sake of efficiency, this is not a lexicographic
---   ordering. This library makes no guarantees about the particular
---   ordering used, and it is subject to change between major releases.
+-- | __Note__: This library provides no guarantees about the particular ordering
+-- used. Users should not rely on it being the same as the ordering used for
+-- lists. It is subject to change between major versions.
 instance (Ord a, Prim a) => Ord (PrimArray a) where
   compare a1@(PrimArray ba1#) a2@(PrimArray ba2#)
     | sameByteArray ba1# ba2# = EQ

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -573,6 +573,9 @@ instance Ord1 SmallArray where
 #endif
 #endif
 
+-- | __Note__: This library provides no guarantees about the particular ordering
+-- used. Users should not rely on it being the same as the ordering used for
+-- lists. It is subject to change between major versions.
 instance Ord a => Ord (SmallArray a) where
   compare sa1 sa2 = smallArrayLiftCompare compare sa1 sa2
 

--- a/Data/Primitive/UnliftedArray.hs
+++ b/Data/Primitive/UnliftedArray.hs
@@ -496,6 +496,9 @@ instance (Eq a, PrimUnlifted a) => Eq (UnliftedArray a) where
      | i < 0 = True
      | otherwise = indexUnliftedArray aa1 i == indexUnliftedArray aa2 i && loop (i-1)
 
+-- | __Note__: This library provides no guarantees about the particular ordering
+-- used. Users should not rely on it being the same as the ordering used for
+-- lists. It is subject to change between major versions.
 instance (Ord a, PrimUnlifted a) => Ord (UnliftedArray a) where
   compare a1 a2 = loop 0
     where


### PR DESCRIPTION
This is another stab at what https://github.com/haskell/primitive/pull/68 tried to do. I've gone a little further though. I've added similar warnings around *all* of the `Ord` instances. This is important because in a future version of `primitive`, we should probably change the `Ord` instance for `Array` to compare the lengths first.