### PR TITLE
add since metadata from 0.6 to 0.6.3

### DIFF
--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -78,6 +78,8 @@ class Monad m => PrimMonad m where
 -- Unlike 'PrimMonad', this typeclass requires that the @Monad@ be fully
 -- expressed as a state transformer, therefore disallowing other monad
 -- transformers on top of the base @IO@ or @ST@.
+--
+-- @since 0.6.0.0
 class PrimMonad m => PrimBase m where
   -- | Expose the internal structure of the monad
   internal :: m a -> State# (PrimState m) -> (# State# (PrimState m), a #)
@@ -98,6 +100,7 @@ instance PrimBase IO where
   internal (IO p) = p
   {-# INLINE internal #-}
 
+-- | @since 0.6.3.0
 instance PrimMonad m => PrimMonad (ContT r m) where
   type PrimState (ContT r m) = PrimState m
   primitive = lift . primitive
@@ -107,6 +110,8 @@ instance PrimMonad m => PrimMonad (IdentityT m) where
   type PrimState (IdentityT m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+
+-- | @since 0.6.2.0
 instance PrimBase m => PrimBase (IdentityT m) where
   internal (IdentityT m) = internal m
   {-# INLINE internal #-}
@@ -154,6 +159,7 @@ instance PrimMonad m => PrimMonad (ExceptT e m) where
 #endif
 
 #if MIN_VERSION_transformers(0,5,3)
+-- | @since 0.6.3.0
 instance ( Monoid w
          , PrimMonad m
 # if !(MIN_VERSION_base(4,8,0))
@@ -216,11 +222,15 @@ primToST :: PrimBase m => m a -> ST (PrimState m) a
 primToST = primToPrim
 
 -- | Convert an 'IO' action to a 'PrimMonad'.
+-- 
+-- @since 0.6.2.0
 ioToPrim :: (PrimMonad m, PrimState m ~ RealWorld) => IO a -> m a
 {-# INLINE ioToPrim #-}
 ioToPrim = primToPrim
 
 -- | Convert an 'ST' action to a 'PrimMonad'.
+--
+-- @since 0.6.2.0
 stToPrim :: PrimMonad m => ST (PrimState m) a -> m a
 {-# INLINE stToPrim #-}
 stToPrim = primToPrim
@@ -244,12 +254,16 @@ unsafePrimToIO = unsafePrimToPrim
 
 -- | Convert an 'ST' action with an arbitraty state token to any 'PrimMonad'.
 -- This operation is highly unsafe!
+-- 
+-- @since 0.6.2.0
 unsafeSTToPrim :: PrimMonad m => ST s a -> m a
 {-# INLINE unsafeSTToPrim #-}
 unsafeSTToPrim = unsafePrimToPrim
 
 -- | Convert an 'IO' action to any 'PrimMonad'. This operation is highly
 -- unsafe!
+--
+-- @since 0.6.2.0
 unsafeIOToPrim :: PrimMonad m => IO a -> m a
 {-# INLINE unsafeIOToPrim #-}
 unsafeIOToPrim = unsafePrimToPrim
@@ -272,6 +286,8 @@ touch x = unsafePrimToPrim
         $ (primitive (\s -> case touch# x s of { s' -> (# s', () #) }) :: IO ())
 
 -- | Create an action to force a value; generalizes 'Control.Exception.evaluate'
+--
+-- @since 0.6.2.0
 evalPrim :: forall a m . PrimMonad m => a -> m a
 #if MIN_VERSION_base(4,4,0)
 evalPrim a = primitive (\s -> seq# a s)

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -738,6 +738,7 @@ instance MonadFix Array where
       err = error "mfix for Data.Primitive.Array applied to strict function."
 
 #if MIN_VERSION_base(4,9,0)
+-- | @since 0.6.3.0
 instance Semigroup (Array a) where
   (<>) = (<|>)
   sconcat = mconcat . F.toList

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -407,6 +407,7 @@ instance Typeable s => Data (MutableByteArray s) where
   gunfold _ _ = error "gunfold"
   dataTypeOf _ = mkNoRepType "Data.Primitive.ByteArray.MutableByteArray"
 
+-- | @since 0.6.3.0
 instance Show ByteArray where
   showsPrec _ ba =
       showString "[" . go 0
@@ -447,6 +448,7 @@ sameByteArray ba1 ba2 =
       0# -> False
 #endif
 
+-- | @since 0.6.3.0
 instance Eq ByteArray where
   ba1@(ByteArray ba1#) == ba2@(ByteArray ba2#)
     | sameByteArray ba1# ba2# = True
@@ -462,6 +464,8 @@ instance Eq ByteArray where
 -- before checking for length equality. Getting the length requires deferencing
 -- the pointers, which could cause accesses to memory that is not in the cache.
 -- By contrast, a pointer equality check is always extremely cheap.
+
+-- | @since 0.6.3.0
 instance Ord ByteArray where
   ba1@(ByteArray ba1#) `compare` ba2@(ByteArray ba2#)
     | sameByteArray ba1# ba2# = EQ
@@ -528,6 +532,7 @@ instance Monoid ByteArray where
   mconcat = concatByteArray
 
 #if __GLASGOW_HASKELL__ >= 708
+-- | @since 0.6.3.0
 instance Exts.IsList ByteArray where
   type Item ByteArray = Word8
 

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -850,6 +850,7 @@ instance MonadFix SmallArray where
       err = error "mfix for Data.Primitive.SmallArray applied to strict function."
 
 #if MIN_VERSION_base(4,9,0)
+-- | @since 0.6.3.0
 instance Sem.Semigroup (SmallArray a) where
   (<>) = (<|>)
   sconcat = mconcat . toList

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -128,10 +128,14 @@ class Prim a where
   setOffAddr# :: Addr# -> Int# -> Int# -> a -> State# s -> State# s
 
 -- | Size of values of type @a@. The argument is not used.
+--
+-- @since 0.6.3.0
 sizeOf :: Prim a => a -> Int
 sizeOf x = I# (sizeOf# x)
 
 -- | Alignment of values of type @a@. The argument is not used.
+--
+-- @since 0.6.3.0
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
 

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -129,13 +129,15 @@ class Prim a where
 
 -- | Size of values of type @a@. The argument is not used.
 --
--- @since 0.6.3.0
+-- This function has existed since 0.1, but was moved from 'Data.Primitive'
+-- to 'Data.Primitive.Types' in version 0.6.3.0
 sizeOf :: Prim a => a -> Int
 sizeOf x = I# (sizeOf# x)
 
 -- | Alignment of values of type @a@. The argument is not used.
 --
--- @since 0.6.3.0
+-- This function has existed since 0.1, but was moved from 'Data.Primitive'
+-- to 'Data.Primitive.Types' in version 0.6.3.0
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
 


### PR DESCRIPTION
@andrewthad added `since` metadata for everything coming up in 0.6.4.0, this PR adds stuff for 0.6.0.0 to 0.6.3.0