### PR TITLE
add benchmarks for different implementations of inequality functions

### DIFF
--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -159,6 +159,7 @@ instance (Eq a, Prim a) => Eq (PrimArray a) where
     loop !i
       | i < 0 = True
       | otherwise = indexPrimArray a1 i == indexPrimArray a2 i && loop (i-1)
+  {-# INLINE (==) #-}
 
 -- | Lexicographic ordering. Subject to change between major versions.
 -- 
@@ -174,6 +175,7 @@ instance (Ord a, Prim a) => Ord (PrimArray a) where
     loop !i
       | i < sz = compare (indexPrimArray a1 i) (indexPrimArray a2 i) <> loop (i+1)
       | otherwise = compare sz1 sz2
+  {-# INLINE compare #-}
 
 #if MIN_VERSION_base(4,7,0)
 -- | @since 0.6.4.0

--- a/bench/PrimArray/Compare.hs
+++ b/bench/PrimArray/Compare.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module PrimArray.Compare
+  ( benchmarkLt
+  , benchmarkLtDef
+  , benchmarkLte
+  , benchmarkLteDef
+  , argumentA
+  , argumentB
+  ) where
+
+import Data.Primitive
+import Data.Word
+import Control.Monad
+import Control.Monad.ST (runST)
+import GHC.Exts (fromList)
+
+benchmarkLtDef :: PrimArray Int -> PrimArray Int -> Bool
+benchmarkLtDef a b = case compare a b of
+  LT -> True
+  _ -> False
+
+benchmarkLteDef :: PrimArray Int -> PrimArray Int -> Bool
+benchmarkLteDef a b = case compare a b of
+  GT -> False
+  _ -> True
+
+benchmarkLt :: PrimArray Int -> PrimArray Int -> Bool
+benchmarkLt a b =
+  let !sz1 = sizeofPrimArray a
+      !sz2 = sizeofPrimArray b
+      !sz = min sz1 sz2
+      loop !i
+        | i < sz = if indexPrimArray a i < indexPrimArray b i
+            then True
+            else loop (i + 1)
+        | otherwise = sz1 < sz2
+   in loop 0
+
+benchmarkLte :: PrimArray Int -> PrimArray Int -> Bool
+benchmarkLte a b =
+  let !sz1 = sizeofPrimArray a
+      !sz2 = sizeofPrimArray b
+      !sz = min sz1 sz2
+      loop !i
+        | i < sz = if indexPrimArray a i <= indexPrimArray b i
+            then loop (i + 1)
+            else False
+        | otherwise = sz1 < sz2
+   in loop 0
+
+argumentA :: PrimArray Int
+argumentA = fromList (enumFromTo 0 8000 ++ [55])
+
+argumentB :: PrimArray Int
+argumentB = fromList (enumFromTo 0 8000 ++ [56])
+

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -23,6 +23,7 @@ import qualified Array.Traverse.Closure
 -- These are particular scenarios that are tested against the
 -- implementations actually used by primitive.
 import qualified ByteArray.Compare
+import qualified PrimArray.Compare
 import qualified PrimArray.Traverse
 
 main :: IO ()
@@ -47,6 +48,16 @@ main = defaultMain
       [ bgroup "Maybe"
         [ bench "Applicative" (whnf PrimArray.Traverse.benchmarkApplicative PrimArray.Traverse.argument)
         , bench "PrimMonad" (whnf PrimArray.Traverse.benchmarkPrimMonad PrimArray.Traverse.argument)
+        ]
+      ]
+    , bgroup "implementations"
+      [ bgroup "less-than"
+        [ bench "default" (whnf (PrimArray.Compare.benchmarkLtDef PrimArray.Compare.argumentA) PrimArray.Compare.argumentB)
+        , bench "override" (whnf (PrimArray.Compare.benchmarkLt PrimArray.Compare.argumentA) PrimArray.Compare.argumentB)
+        ]
+      , bgroup "less-than-equal"
+        [ bench "default" (whnf (PrimArray.Compare.benchmarkLteDef PrimArray.Compare.argumentA) PrimArray.Compare.argumentB)
+        , bench "override" (whnf (PrimArray.Compare.benchmarkLte PrimArray.Compare.argumentA) PrimArray.Compare.argumentB)
         ]
       ]
     ]

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -39,6 +39,7 @@ benchmark bench
     Array.Traverse.Closure
     Array.Traverse.Unsafe
     ByteArray.Compare
+    PrimArray.Compare
     PrimArray.Traverse
   build-depends:
       base >= 4.8 && < 4.12


### PR DESCRIPTION
Also, this PR adds missing `INLINE` pragmas for the implementations of `compare` and `==` for `PrimArray`. I noticed they were missing, and it made them run way slower.

Sadly, the benchmarks do not actually show what I hoped they would. I thought that overriding the default implementation of `<` and `<=` would make them faster, but this does not appear to be the case:

```
benchmarked PrimArray/implementations/less-than/default
time                 4.403 μs   (4.381 μs .. 4.426 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.426 μs   (4.411 μs .. 4.453 μs)
std dev              66.35 ns   (39.42 ns .. 97.83 ns)

benchmarked PrimArray/implementations/less-than/override
time                 4.379 μs   (4.368 μs .. 4.392 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 4.395 μs   (4.385 μs .. 4.416 μs)
std dev              52.01 ns   (30.93 ns .. 92.81 ns)

benchmarked PrimArray/implementations/less-than-equal/default
time                 4.437 μs   (4.405 μs .. 4.495 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 4.427 μs   (4.411 μs .. 4.453 μs)
std dev              68.13 ns   (45.53 ns .. 93.14 ns)

benchmarked PrimArray/implementations/less-than-equal/override
time                 4.389 μs   (4.374 μs .. 4.407 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.385 μs   (4.380 μs .. 4.392 μs)
std dev              20.59 ns   (15.33 ns .. 26.22 ns)
```

Regardless, I think it's worth keeping these benchmarks around and adding the missing pragmas.
