### PR TITLE
Fix build error by recent ghc-head

### DIFF
--- a/Data/Primitive/MutVar.hs
+++ b/Data/Primitive/MutVar.hs
@@ -25,7 +25,7 @@ module Data.Primitive.MutVar (
 ) where
 
 import Control.Monad.Primitive ( PrimMonad(..), primitive_ )
-import GHC.Prim ( MutVar#, sameMutVar#, newMutVar#,
+import GHC.Exts ( MutVar#, sameMutVar#, newMutVar#,
                   readMutVar#, writeMutVar#, atomicModifyMutVar# )
 import Data.Primitive.Internal.Compat ( isTrue# )
 import Data.Typeable ( Typeable )
@@ -83,4 +83,3 @@ modifyMutVar' :: PrimMonad m => MutVar (PrimState m) a -> (a -> a) -> m ()
 modifyMutVar' (MutVar mv#) g = primitive_ $ \s# ->
   case readMutVar# mv# s# of
     (# s'#, a #) -> let a' = g a in a' `seq` writeMutVar# mv# a' s'#
-


### PR DESCRIPTION
A recent [commit](https://github.com/ghc/ghc/commit/af9b744bbf1c39078e561b19edd3c5234b361b27) in ghc removed `GHC.Prim.atomicModifyMutVar#` which breaks `Data.Primitive.MutVar`. An implementation of `atomicModifyMutVar#` is provided in `GHC.Exts` instead, so I intend to fix the build error by simply replacing `GHC.Prim` with `GHC.Exts`.