### PR TITLE
Set the stage for UnliftedArray#

### DIFF
--- a/Data/Primitive/Types/PrimUnlifted.hs
+++ b/Data/Primitive/Types/PrimUnlifted.hs
@@ -1,0 +1,302 @@
+{-# language CPP #-}
+{-# language MagicHash #-}
+{-# language TypeFamilies #-}
+{-# language DataKinds #-}
+{-# language DefaultSignatures #-}
+{-# language ScopedTypeVariables #-}
+
+-- |
+-- Module      : Data.Primitive.UnliftedArray
+-- Copyright   : (c) Dan Doel 2016, (c) David Feuer 2018
+-- License     : BSD-style
+--
+-- Maintainer  : Libraries <libraries@haskell.org>
+-- Portability : non-portable
+--
+-- Note: In a previous release, there was a `PrimUnlifted` instance for
+-- `StablePtr`. However, since `StablePtr#` is not of kind `TYPE UnliftedRep`,
+-- and is treated very differently by the garbage collector, this instance was
+-- unsound, and it has been removed.
+--
+-- @since TODO
+
+module Data.Primitive.Types.PrimUnlifted
+ ( PrimUnlifted (..)
+#if __GLASGOW_HASKELL__ < 800
+ , Unlifted
+ , toUnlifted#
+ , fromUnlifted#
+#endif
+ ) where
+
+import GHC.Exts
+
+import Data.Primitive.PrimArray (PrimArray (..), MutablePrimArray (..))
+import Data.Primitive.Array (Array (..), MutableArray (..))
+import Data.Primitive.SmallArray (SmallArray (..), SmallMutableArray (..))
+import Data.Primitive.ByteArray (ByteArray (..), MutableByteArray (..))
+import Data.Primitive.MutVar (MutVar (..))
+import GHC.MVar (MVar(..))
+import GHC.Conc (TVar(..))
+import GHC.Weak (Weak(..))
+import GHC.Conc.Sync (ThreadId(..))
+
+-- | Classifies the types that are just liftings of unlifted pointer
+-- types.
+--
+-- For GHC versions 8.0 and later, instances should define 'Unlift',
+-- 'toUnlifted#', and 'fromUnlifted#'. When compiled with earlier versions,
+-- @Unlifted a@ is always a synonym for 'ArrayArray#', and instances should
+-- define 'toArrayArray#' and 'fromArrayArray#', coercing the internal
+-- unlifted types to and from 'ArrayArray#'.
+--
+-- Note: 'toArrayArray#' and 'fromArrayArray#' will eventually be
+-- deprecated and removed. They should be used /only/ to define instances
+-- for GHC versions before 8.0.
+class PrimUnlifted a where
+#if __GLASGOW_HASKELL__ >= 800
+  -- Technically speaking, this is too strong; users *can* write
+  -- working instances with just toArrayArray# and fromArrayArray#.
+  -- But we really want to push them in the right direction for the
+  -- future.
+  {-# MINIMAL toUnlifted#, fromUnlifted# #-}
+  -- | The unlifted pointer representation of a type. For example, since
+  -- 'MutVar' is defined
+  --
+  -- @
+  -- data MutVar s a = MutVar (MutVar# s a)
+  -- @
+  --
+  -- we define
+  --
+  -- @
+  -- type Unlifted (MutVar s a) = MutVar# s a
+  -- @
+  --
+  -- @since TODO
+#  if __GLASGOW_HASKELL__ >= 802
+  type Unlifted a :: TYPE 'UnliftedRep
+#  else
+  type Unlifted a :: TYPE 'PtrRepUnlifted
+#  endif
+  type Unlifted a = ArrayArray#
+
+  -- | Convert a value to its unlifted representation.
+  --
+  -- @since TODO
+  toUnlifted# :: a -> Unlifted a
+  default toUnlifted#
+    :: Unlifted a ~ ArrayArray#
+    => a -> Unlifted a
+  toUnlifted# = toArrayArray#
+
+  -- Convert a value from its unlifted representation.
+  --
+  -- @since TODO
+  fromUnlifted# :: Unlifted a -> a
+  default fromUnlifted#
+    :: Unlifted a ~ ArrayArray#
+    => Unlifted a -> a
+  fromUnlifted# = fromArrayArray#
+#elif __GLASGOW_HASKELL__ >= 708
+  {-# MINIMAL toArrayArray#, fromArrayArray# #-}
+#endif
+
+  -- | Convert the value to an 'ArrayArray#'.
+  toArrayArray# :: a -> ArrayArray#
+#if __GLASGOW_HASKELL__ >= 800
+  toArrayArray# a = unsafeCoerce# (toUnlifted# a)
+#endif
+
+  -- | Convert an 'ArrayArray#' to the value.
+  fromArrayArray# :: ArrayArray# -> a
+#if __GLASGOW_HASKELL__ >= 800
+  fromArrayArray# a# = fromUnlifted# (unsafeCoerce# a#)
+#endif
+
+#if __GLASGOW_HASKELL__ < 800
+-- | For GHC versions below 8.0, we define @Unlifted a = ArrayArray#@
+-- regardless of the true type structure. This is necessary because
+-- earlier versions don't allow a type family to produce an unlifted
+-- result. Users should always prefer 'Unlift' to 'ArrayArray#' for
+-- forwards compatibility.
+type Unlifted a = ArrayArray#
+
+-- Why do we define these as functions instead of class methods with
+-- defaults when __GLASGOW_HASKELL__ < 800? Some users feel virtuous
+-- when they define all the methods for a class, even when there are
+-- defaults. Such a user might be sorely tempted to define 'toUnlifted#'
+-- and 'fromUnlifted#' the same as 'toArrayArray#' and 'fromArrayArray#'.
+-- That ugly code will continue to compile and run correctly under
+-- later GHC versions, and never get fixed. Since there's no point
+-- in allowing that, we just don't.
+
+-- | Convert a value to its unlifted representation.
+toUnlifted# :: PrimUnlifted a => a -> Unlifted a
+toUnlifted# = toArrayArray#
+
+-- | Convert a value from its unlifted representation.
+fromUnlifted# :: PrimUnlifted a => Unlifted a -> a
+fromUnlifted# = fromArrayArray#
+#endif
+
+instance PrimUnlifted (Array a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (Array a) = Array# a
+
+  toUnlifted# (Array aa#) = aa#
+  fromUnlifted# aa# = Array aa#
+#else
+  toArrayArray# (Array a#) = unsafeCoerce# a#
+  fromArrayArray# aa# = Array (unsafeCoerce# aa#)
+#endif
+
+instance PrimUnlifted (MutableArray s a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MutableArray s a) = MutableArray# s a
+
+  toUnlifted# (MutableArray ma#) = ma#
+  fromUnlifted# aa# = MutableArray aa#
+#else
+  toArrayArray# (MutableArray ma#) = unsafeCoerce# ma#
+  fromArrayArray# aa# = MutableArray (unsafeCoerce# aa#)
+#endif
+
+instance PrimUnlifted ByteArray where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted ByteArray = ByteArray#
+
+  toUnlifted# (ByteArray ba#) = ba#
+  fromUnlifted# ba# = ByteArray ba#
+#else
+  toArrayArray# (ByteArray ba#) = unsafeCoerce# ba#
+  fromArrayArray# aa# = ByteArray (unsafeCoerce# aa#)
+#endif
+
+instance PrimUnlifted (MutableByteArray s) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MutableByteArray s) = MutableByteArray# s
+
+  toUnlifted# (MutableByteArray ba#) = ba#
+  fromUnlifted# ba# = MutableByteArray ba#
+#else
+  toArrayArray# (MutableByteArray mba#) = unsafeCoerce# mba#
+  fromArrayArray# aa# = MutableByteArray (unsafeCoerce# aa#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted (PrimArray a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (PrimArray a) = ByteArray#
+
+  toUnlifted# (PrimArray ba#) = ba#
+  fromUnlifted# ba# = PrimArray ba#
+#else
+  toArrayArray# (PrimArray ba#) = unsafeCoerce# ba#
+  fromArrayArray# aa# = PrimArray (unsafeCoerce# aa#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted (MutablePrimArray s a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MutablePrimArray s a) = MutableByteArray# s
+
+  toUnlifted# (MutablePrimArray ba#) = ba#
+  fromUnlifted# ba# = MutablePrimArray ba#
+#else
+  toArrayArray# (MutablePrimArray mba#) = unsafeCoerce# mba#
+  fromArrayArray# aa# = MutablePrimArray (unsafeCoerce# aa#)
+#endif
+
+instance PrimUnlifted (SmallArray a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (SmallArray a) = SmallArray# a
+
+  toUnlifted# (SmallArray sa#) = sa#
+  fromUnlifted# = SmallArray
+#elif __GLASGOW_HASKELL__ >= 710
+  toArrayArray# (SmallArray sa#) =
+    unsafeCoerce# (sa# :: SmallArray# a)
+  fromArrayArray# aa# =
+    SmallArray (unsafeCoerce# aa# :: SmallArray# a)
+#else
+  -- SmallArray is a newtype
+  toArrayArray# (SmallArray ar) = toArrayArray# ar
+  fromArrayArray# aa# = SmallArray (fromArrayArray# aa#)
+#endif
+
+instance PrimUnlifted (SmallMutableArray s a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (SmallMutableArray s a) = SmallMutableArray# s a
+
+  toUnlifted# (SmallMutableArray sa#) = sa#
+  fromUnlifted# = SmallMutableArray
+#elif __GLASGOW_HASKELL__ >= 710
+  toArrayArray# (SmallMutableArray sma#) =
+    unsafeCoerce# (sma# :: SmallMutableArray# s a)
+  fromArrayArray# aa# =
+    SmallMutableArray (unsafeCoerce# aa# :: SmallMutableArray# s a)
+#else
+  -- SmallMutableArray is a newtype
+  toArrayArray# (SmallMutableArray ar) = toArrayArray# ar
+  fromArrayArray# aa# = SmallMutableArray (fromArrayArray# aa#)
+#endif
+
+instance PrimUnlifted (MutVar s a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MutVar s a) = MutVar# s a
+
+  toUnlifted# (MutVar ref) = ref
+  fromUnlifted# = MutVar
+#else
+  toArrayArray# (MutVar mv#) = unsafeCoerce# mv#
+  fromArrayArray# aa# = MutVar (unsafeCoerce# aa#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted (MVar a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MVar a) = MVar# RealWorld a
+
+  toUnlifted# (MVar mv#) = mv#
+  fromUnlifted# = MVar
+#else
+  toArrayArray# (MVar mv#) = unsafeCoerce# mv#
+  fromArrayArray# mv# = MVar (unsafeCoerce# mv#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted (TVar a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (TVar a) = TVar# RealWorld a
+
+  toUnlifted# (TVar tv#) = tv#
+  fromUnlifted# = TVar
+#else
+  toArrayArray# (TVar tv#) = unsafeCoerce# tv#
+  fromArrayArray# tv# = TVar (unsafeCoerce# tv#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted (Weak a) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (Weak a) = Weak# a
+
+  toUnlifted# (Weak wk#) = wk#
+  fromUnlifted# = Weak
+#else
+  toArrayArray# (Weak tv#) = unsafeCoerce# tv#
+  fromArrayArray# tv# = Weak (unsafeCoerce# tv#)
+#endif
+
+-- | @since 0.6.4.0
+instance PrimUnlifted ThreadId where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted ThreadId = ThreadId#
+
+  toUnlifted# (ThreadId tid#) = tid#
+  fromUnlifted# = ThreadId
+#else
+  toArrayArray# (ThreadId tv#) = unsafeCoerce# tv#
+  fromArrayArray# tv# = ThreadId (unsafeCoerce# tv#)
+#endif

--- a/Data/Primitive/UnliftedArray.hs
+++ b/Data/Primitive/UnliftedArray.hs
@@ -42,17 +42,18 @@
 -- 'MutableUnliftedArray' are parameterized by the type of arrays they contain, and
 -- the coercions necessary are abstracted into a class, 'PrimUnlifted', of things
 -- that are eligible to be stored.
---
--- Note: In a previous release, there was a `PrimUnlifted` instance for
--- `StablePtr`. However, since `StablePtr#` is not of kind `TYPE UnliftedRep`,
--- and is treated very differently by the garbage collector, this instance was
--- unsound, and it has been removed.
 
 module Data.Primitive.UnliftedArray
   ( -- * Types
     UnliftedArray(..)
   , MutableUnliftedArray(..)
-  , PrimUnlifted(..)
+  -- We don't *really* want to export the PrimUnlifted methods from
+  -- this module anymore; users should import Data.Primitive.Types.PrimUnlifted
+  -- to define PrimUnlifted instances or use PrimUnlifted methods. But since
+  -- this module used to define PrimUnlifted, we need to export the *legacy*
+  -- methods for backwards compatibility. Eventually (a couple versions
+  -- after we stop supporting GHC <8.0), we can quit doing that.
+  , PrimUnlifted(toArrayArray#, fromArrayArray#)
     -- * Operations
   , unsafeNewUnliftedArray
   , newUnliftedArray
@@ -87,32 +88,27 @@ module Data.Primitive.UnliftedArray
 --  , unsafeThawUnliftedArray
   ) where
 
+#if __GLASGOW_HASKELL__ < 710
 import Data.Typeable
 import Control.Applicative
+#endif
 
-import GHC.Prim
+import GHC.Exts
 import GHC.Base (Int(..),build)
 
 import Control.Monad.Primitive
 
+#if !MIN_VERSION_base(4,9,0)
 import Control.Monad.ST (runST,ST)
+#else
+import Control.Monad.ST (ST)
+#endif
 
-import Data.Monoid (Monoid,mappend)
+import Data.Monoid (Monoid (..))
 import Data.Primitive.Internal.Compat ( isTrue# )
 
+import Data.Primitive.Types.PrimUnlifted
 import qualified Data.List as L
-import           Data.Primitive.Array (Array)
-import qualified Data.Primitive.Array as A
-import           Data.Primitive.ByteArray (ByteArray)
-import qualified Data.Primitive.ByteArray as BA
-import qualified Data.Primitive.PrimArray as PA
-import qualified Data.Primitive.SmallArray as SA
-import qualified Data.Primitive.MutVar as MV
-import qualified Data.Monoid
-import qualified GHC.MVar as GM (MVar(..))
-import qualified GHC.Conc as GC (TVar(..))
-import qualified GHC.Weak as GW (Weak(..))
-import qualified GHC.Conc.Sync as GCS (ThreadId(..))
 import qualified GHC.Exts as E
 import qualified GHC.ST as GHCST
 
@@ -131,103 +127,43 @@ import GHC.Base (runRW#)
 -- around unlifted primitive types. The values of the unlifted type are
 -- stored directly, eliminating a layer of indirection.
 data UnliftedArray e = UnliftedArray ArrayArray#
+#if __GLASGOW_HASKELL__ < 710
   deriving (Typeable)
+#endif
+
+instance PrimUnlifted (UnliftedArray e) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (UnliftedArray e) = ArrayArray#
+
+  toUnlifted# (UnliftedArray aa#) = aa#
+  fromUnlifted# aa# = UnliftedArray aa#
+#endif
+  -- Unlike all other PrimUnlifted instances, we implement
+  -- the legacy methods regardless of GHC version because
+  -- we can avoid unsafe coercions altogether. It shouldn't
+  -- really matter, but it seems cleaner.
+  toArrayArray# (UnliftedArray aa#) = aa#
+  fromArrayArray# aa# = UnliftedArray aa#
 
 -- | Mutable arrays that efficiently store types that are simple wrappers
 -- around unlifted primitive types. The values of the unlifted type are
 -- stored directly, eliminating a layer of indirection.
 data MutableUnliftedArray s e = MutableUnliftedArray (MutableArrayArray# s)
+#if __GLASGOW_HASKELL__ < 710
   deriving (Typeable)
-
--- | Classifies the types that are able to be stored in 'UnliftedArray' and
--- 'MutableUnliftedArray'. These should be types that are just liftings of the
--- unlifted pointer types, so that their internal contents can be safely coerced
--- into an 'ArrayArray#'.
-class PrimUnlifted a where
-  toArrayArray# :: a -> ArrayArray#
-  fromArrayArray# :: ArrayArray# -> a
-
-instance PrimUnlifted (UnliftedArray e) where
-  toArrayArray# (UnliftedArray aa#) = aa#
-  fromArrayArray# aa# = UnliftedArray aa#
+#endif
 
 instance PrimUnlifted (MutableUnliftedArray s e) where
+#if __GLASGOW_HASKELL__ >= 800
+  type Unlifted (MutableUnliftedArray s e) = MutableArrayArray# s
+
+  toUnlifted# (MutableUnliftedArray maa#) = maa#
+  fromUnlifted# aa# = MutableUnliftedArray aa#
+#else
   toArrayArray# (MutableUnliftedArray maa#) = unsafeCoerce# maa#
   fromArrayArray# aa# = MutableUnliftedArray (unsafeCoerce# aa#)
-
-instance PrimUnlifted (Array a) where
-  toArrayArray# (A.Array a#) = unsafeCoerce# a#
-  fromArrayArray# aa# = A.Array (unsafeCoerce# aa#)
-
-instance PrimUnlifted (A.MutableArray s a) where
-  toArrayArray# (A.MutableArray ma#) = unsafeCoerce# ma#
-  fromArrayArray# aa# = A.MutableArray (unsafeCoerce# aa#)
-
-instance PrimUnlifted ByteArray where
-  toArrayArray# (BA.ByteArray ba#) = unsafeCoerce# ba#
-  fromArrayArray# aa# = BA.ByteArray (unsafeCoerce# aa#)
-
-instance PrimUnlifted (BA.MutableByteArray s) where
-  toArrayArray# (BA.MutableByteArray mba#) = unsafeCoerce# mba#
-  fromArrayArray# aa# = BA.MutableByteArray (unsafeCoerce# aa#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted (PA.PrimArray a) where
-  toArrayArray# (PA.PrimArray ba#) = unsafeCoerce# ba#
-  fromArrayArray# aa# = PA.PrimArray (unsafeCoerce# aa#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted (PA.MutablePrimArray s a) where
-  toArrayArray# (PA.MutablePrimArray mba#) = unsafeCoerce# mba#
-  fromArrayArray# aa# = PA.MutablePrimArray (unsafeCoerce# aa#)
-
-instance PrimUnlifted (SA.SmallArray a) where
-#if __GLASGOW_HASKELL__ >= 710
-  toArrayArray# (SA.SmallArray sa#) =
-    unsafeCoerce# (sa# :: SmallArray# a)
-  fromArrayArray# aa# =
-    SA.SmallArray (unsafeCoerce# aa# :: SmallArray# a)
-#else
-  -- SmallArray is a newtype around Array.
-  toArrayArray# (SA.SmallArray sa) = toArrayArray# sa
-  fromArrayArray# aa# = SA.SmallArray (fromArrayArray# aa#)
 #endif
 
-instance PrimUnlifted (SA.SmallMutableArray s a) where
-#if __GLASGOW_HASKELL__ >= 710
-  toArrayArray# (SA.SmallMutableArray sma#) =
-    unsafeCoerce# (sma# :: SmallMutableArray# s a)
-  fromArrayArray# aa# =
-    SA.SmallMutableArray (unsafeCoerce# aa# :: SmallMutableArray# s a)
-#else
-  -- SmallMutableArray is a newtype around MutableArray
-  toArrayArray# (SA.SmallMutableArray sa) = toArrayArray# sa
-  fromArrayArray# aa# = SA.SmallMutableArray (fromArrayArray# aa#)
-#endif
-
-instance PrimUnlifted (MV.MutVar s a) where
-  toArrayArray# (MV.MutVar mv#) = unsafeCoerce# mv#
-  fromArrayArray# aa# = MV.MutVar (unsafeCoerce# aa#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted (GM.MVar a) where
-  toArrayArray# (GM.MVar mv#) = unsafeCoerce# mv#
-  fromArrayArray# mv# = GM.MVar (unsafeCoerce# mv#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted (GC.TVar a) where
-  toArrayArray# (GC.TVar tv#) = unsafeCoerce# tv#
-  fromArrayArray# tv# = GC.TVar (unsafeCoerce# tv#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted (GW.Weak a) where
-  toArrayArray# (GW.Weak tv#) = unsafeCoerce# tv#
-  fromArrayArray# tv# = GW.Weak (unsafeCoerce# tv#)
-
--- | @since 0.6.4.0
-instance PrimUnlifted GCS.ThreadId where
-  toArrayArray# (GCS.ThreadId tv#) = unsafeCoerce# tv#
-  fromArrayArray# tv# = GCS.ThreadId (unsafeCoerce# tv#)
 
 die :: String -> String -> a
 die fun problem = error $ "Data.Primitive.UnliftedArray." ++ fun ++ ": " ++ problem

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -40,6 +40,7 @@ Library
         Data.Primitive
         Data.Primitive.MachDeps
         Data.Primitive.Types
+        Data.Primitive.Types.PrimUnlifted
         Data.Primitive.Array
         Data.Primitive.ByteArray
         Data.Primitive.PrimArray


### PR DESCRIPTION
The `PrimUnlifted` class, used to implement `UnliftedArray`
operations, is currently based on an `ArrayArray#` representation
of unlifted arrays. But that's set to change, hopefully soon.
I don't think it's too soon to set up the machinery necessary to
allow users to write code *today* that will work once `ArrayArray#`
is gone.

The key here is to add an associated type family to `PrimUnlifted`
that ties each `LiftedRep` type to its `UnliftedRep` counterpart,
and methods that convert back and forth.