### PR TITLE
 Add Prim instances for stable things

### DIFF
--- a/Data/Primitive/Internal/Operations.hs
+++ b/Data/Primitive/Internal/Operations.hs
@@ -17,13 +17,15 @@ module Data.Primitive.Internal.Operations (
   setWord64Array#, setWordArray#,
   setInt8Array#, setInt16Array#, setInt32Array#,
   setInt64Array#, setIntArray#,
-  setAddrArray#, setFloatArray#, setDoubleArray#, setWideCharArray#,
+  setAddrArray#, setStablePtrArray#, setFloatArray#, setDoubleArray#,
+  setWideCharArray#,
 
   setWord8OffAddr#, setWord16OffAddr#, setWord32OffAddr#,
   setWord64OffAddr#, setWordOffAddr#,
   setInt8OffAddr#, setInt16OffAddr#, setInt32OffAddr#,
   setInt64OffAddr#, setIntOffAddr#,
-  setAddrOffAddr#, setFloatOffAddr#, setDoubleOffAddr#, setWideCharOffAddr#
+  setAddrOffAddr#, setFloatOffAddr#, setDoubleOffAddr#, setWideCharOffAddr#,
+  setStablePtrOffAddr#
 ) where
 
 import Data.Primitive.MachDeps (Word64_#, Int64_#)
@@ -52,6 +54,8 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setIntArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
   setAddrArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Addr# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
+  setStablePtrArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> StablePtr# a -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Float"
   setFloatArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Float# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Double"
@@ -81,6 +85,8 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setIntOffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
   setAddrOffAddr# :: Addr# -> CPtrdiff -> CSize -> Addr# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
+  setStablePtrOffAddr# :: Addr# -> CPtrdiff -> CSize -> StablePtr# a -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Float"
   setFloatOffAddr# :: Addr# -> CPtrdiff -> CSize -> Float# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Double"

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE DeriveGeneric #-}
 #endif
 
 #include "HsBaseConfig.h"
@@ -48,6 +49,9 @@ import GHC.Int (
 import GHC.Ptr (
     Ptr(..), FunPtr(..)
   )
+import GHC.Stable (
+    StablePtr(..)
+  )
 
 import GHC.Prim
 #if __GLASGOW_HASKELL__ >= 706
@@ -75,9 +79,21 @@ import GHC.Exts (Down(..))
 #if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as Semigroup
 #endif
+#if __GLASGOW_HASKELL__ >= 800
+import GHC.Generics
+#endif
 
 -- | A machine address
-data Addr = Addr Addr# deriving ( Typeable )
+data Addr = Addr Addr#
+
+#if __GLASGOW_HASKELL__ < 710
+deriving instance Typeable Addr
+#endif
+
+#if __GLASGOW_HASKELL__ >= 800
+-- | @since TODO
+deriving instance Generic Addr
+#endif
 
 instance Show Addr where
   showsPrec _ (Addr a) =
@@ -308,6 +324,9 @@ derivePrim(Addr, Addr, sIZEOF_PTR, aLIGNMENT_PTR,
 derivePrim(Ptr a, Ptr, sIZEOF_PTR, aLIGNMENT_PTR,
            indexAddrArray#, readAddrArray#, writeAddrArray#, setAddrArray#,
            indexAddrOffAddr#, readAddrOffAddr#, writeAddrOffAddr#, setAddrOffAddr#)
+derivePrim(StablePtr a, StablePtr, sIZEOF_PTR, aLIGNMENT_PTR,
+           indexStablePtrArray#, readStablePtrArray#, writeStablePtrArray#, setStablePtrArray#,
+           indexStablePtrOffAddr#, readStablePtrOffAddr#, writeStablePtrOffAddr#, setStablePtrOffAddr#)
 derivePrim(FunPtr a, FunPtr, sIZEOF_PTR, aLIGNMENT_PTR,
            indexAddrArray#, readAddrArray#, writeAddrArray#, setAddrArray#,
            indexAddrOffAddr#, readAddrOffAddr#, writeAddrOffAddr#, setAddrOffAddr#)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 ## Changes in version 0.?.?.?
 
+  * Add a `Prim` instance for `StablePtr` to replace the previous
+    (invalid) `PrimUnlifted` instance.
+
+  * Add a `PrimUnlifted` instance for `StableName`.
+
+  * Add a lot more tests for `PrimArray`.
+
   * Rework the `PrimUnlifted` class so users don't need to use `unsafeCoerce#`
     when writing instances for GHC >= 8.0. Specifically, add an associated
     type family, `Unlifted`, and two methods, `toUnlifted#` and `fromUnlifted#`.

--- a/test/main.hs
+++ b/test/main.hs
@@ -196,7 +196,10 @@ main = do
         -- tests from quickcheck-classes. Since StablePtr values can only
         -- be created in IO and must be explicitly deallocated, we use a
         -- custom property test that is more restricted in what it does.
-      , TQC.testProperty "StablePtr" stablePtrPrimProp
+      , testGroup "StablePtr"
+        [ TQC.testProperty "element" stablePtrPrimProp
+        , TQC.testProperty "block" stablePtrPrimBlockProp
+        ]
       ]
     , testGroup "PrimUnlifted"
       -- Currently, quickcheck-classes does not provide a way to test
@@ -207,7 +210,10 @@ main = do
       [ renameLawsToTest "Array" (QCC.eqLaws (Proxy :: Proxy (UnliftedArray (Array Integer))))
       , renameLawsToTest "SmallArray" (QCC.eqLaws (Proxy :: Proxy (UnliftedArray (SmallArray Integer))))
       , renameLawsToTest "ByteArray" (QCC.eqLaws (Proxy :: Proxy (UnliftedArray ByteArray)))
-      , TQC.testProperty "StableName" stableNameUnliftedPrimProp
+      , testGroup "StableName"
+        [ TQC.testProperty "element" stableNameUnliftedPrimProp
+        , TQC.testProperty "block" stableNameUnliftedPrimBlockProp
+        ]
       ]
     ]
 
@@ -285,6 +291,20 @@ stablePtrPrimProp = QC.property $ \(xs :: [Integer]) -> unsafePerformIO $ do
   mapM_ freeStablePtr ptrs'
   return (xs === ys)
 
+stablePtrPrimBlockProp :: QC.Property
+stablePtrPrimBlockProp = QC.property $ \(x :: Word) (QC.NonNegative (len :: Int)) -> unsafePerformIO $ do
+  ptr <- newStablePtr x
+  let ptrs' = replicatePrimArray len ptr
+  let go ix = if ix < len
+        then do
+          n <- deRefStablePtr (indexPrimArray ptrs' ix)
+          ns <- go (ix + 1)
+          return (n : ns)
+        else return []
+  ys <- go 0
+  freeStablePtr ptr
+  return (L.replicate len x === ys)
+
 -- Tests that writing stable names to an UnliftedArray and reading
 -- them back out gives correct results.
 stableNameUnliftedPrimProp :: QC.Property
@@ -292,6 +312,13 @@ stableNameUnliftedPrimProp = QC.property $ \(xs :: [Integer]) -> unsafePerformIO
   names <- mapM makeStableName xs
   let names' = unliftedArrayToList (unliftedArrayFromList names)
   return (names == names')
+
+stableNameUnliftedPrimBlockProp :: QC.Property
+stableNameUnliftedPrimBlockProp = QC.property $ \(x :: Word) (QC.NonNegative (len :: Int)) -> unsafePerformIO $ do
+  name <- makeStableName x
+  mutArr <- newUnliftedArray len name
+  ptrs' <- unsafeFreezeUnliftedArray mutArr
+  return (L.replicate len name == unliftedArrayToList ptrs')
 
 -- Provide the non-negative integers up to the bound. For example:
 --


### PR DESCRIPTION
Add a `Prim` instance for `StablePtr` and a `PrimUnlifted`
instance for `StableName`.

Closes #201