### PR TITLE
Fix documentation comment for copyMutableArray.

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -235,7 +235,8 @@ copyArray !dst !doff !src !soff !len = go 0
 -- same and the ranges overlap, the copy still works as expected, as if the
 -- region is first copied to a temporary buffer.
 --
--- Note: The order of arguments is different from that of 'copyMutableArray#'.
+-- Note: The order of arguments is different from that of 'copyMutableArray#'. The primop
+-- has the source first while this wrapper has the destination first.
 copyMutableArray :: PrimMonad m
           => MutableArray (PrimState m) a    -- ^ destination array
           -> Int                             -- ^ offset into destination array

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -231,8 +231,11 @@ copyArray !dst !doff !src !soff !len = go 0
          | otherwise = return ()
 #endif
 
--- | Copy a slice of a mutable array to another array. The two arrays may
--- not be the same.
+-- | Copy a slice of a mutable array to another array. If the two arrays are the
+-- same and the ranges overlap, the copy still works as expected, as if the
+-- region is first copied to a temporary buffer.
+--
+-- Note: The order of arguments is different from that of 'copyMutableArray#'.
 copyMutableArray :: PrimMonad m
           => MutableArray (PrimState m) a    -- ^ destination array
           -> Int                             -- ^ offset into destination array


### PR DESCRIPTION
Related question on [StackOverflow](https://stackoverflow.com/questions/53734159/subtle-difference-between-copymutablearray-and-copymutablearray). I hope such a small fix doesn't have to go through the libraries mailing list :sweat_smile: .