### PR TITLE
Improve foldrByteArray

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -261,12 +261,13 @@ writeByteArray (MutableByteArray arr#) (I# i#) x
 
 -- | Right-fold over the elements of a 'ByteArray'.
 foldrByteArray :: forall a b. (Prim a) => (a -> b -> b) -> b -> ByteArray -> b
+{-# INLINE foldrByteArray #-}
 foldrByteArray f z arr = go 0
   where
     go i
-      | sizeofByteArray arr > i * sz = f (indexByteArray arr i) (go (i+1))
-      | otherwise                    = z
-    sz = sizeOf (undefined :: a)
+      | i < maxI  = f (indexByteArray arr i) (go (i+1))
+      | otherwise = z
+    maxI = sizeofByteArray arr `quot` sizeOf (undefined :: a)
 
 byteArrayFromList :: Prim a => [a] -> ByteArray
 byteArrayFromList xs = byteArrayFromListN (length xs) xs

--- a/test/main.hs
+++ b/test/main.hs
@@ -113,6 +113,7 @@ main = do
       , lawsToTest (QCC.showReadLaws (Proxy :: Proxy (Array Int)))
 #if MIN_VERSION_base(4,7,0)
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy ByteArray))
+      , TQC.testProperty "foldrByteArray" (QCCL.foldrProp word8 foldrByteArray)
 #endif
       ]
     , testGroup "PrimArray"
@@ -226,6 +227,9 @@ deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
 #endif
+
+word8 :: Proxy Word8
+word8 = Proxy
 
 int16 :: Proxy Int16
 int16 = Proxy


### PR DESCRIPTION
1. Replace one multiplication per array's element by a single division per call.
2. Add `INLINE` pragma. This is crucial to get `sizeOf (undefined :: a)` specialized, allowing GHC to replace `quot` by a bitmask in CMM.
3. Add a test case.