### PR TITLE
Adapt to MonadFail-related changes in base-4.13

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -45,6 +45,7 @@ import Control.Monad.ST(ST,runST)
 
 import Control.Applicative
 import Control.Monad (MonadPlus(..), when)
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 #if MIN_VERSION_base(4,4,0)
 import Control.Monad.Zip
@@ -700,6 +701,11 @@ instance Monad Array where
      = copyArray smb off sb 0 (lsb)
          *> fill (off + lsb) sbs smb
 
+#if !(MIN_VERSION_base(4,13,0))
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail Array where
   fail _ = empty
 
 instance MonadPlus Array where

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -74,6 +74,7 @@ import qualified GHC.Exts
 
 import Control.Applicative
 import Control.Monad
+import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import Control.Monad.Primitive
 import Control.Monad.ST
@@ -808,6 +809,11 @@ instance Monad SmallArray where
      copySmallArray smb off sb 0 (length sb)
        *> fill (off + length sb) sbs smb
 
+#if !(MIN_VERSION_base(4,13,0))
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail SmallArray where
   fail _ = emptySmallArray
 
 instance MonadPlus SmallArray where

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## Changes in version 0.?.?.?
 
+  * Define `MonadFail` instances for `Array` and `SmallArray`.
+
   * Define `unsafeInterleave`.
 
   * Add a `Prim` instance for `StablePtr` to replace the previous
@@ -16,14 +18,14 @@
     `Data.Primitive.Types.PrimUnlifted`.
 
 ## Changes in version 0.?.?.?
-  
+
   * Remove the `PrimUnlifted` instance for `StablePtr`. This instance would
     cause the GC to crash if someone actually put `StablePtr`s inside
     an `UnliftedArray`.
-    
+
   * Fix the `PrimUnlifted` instances for `SmallArray` and `SmallMutableArray`
     when compiling with GHC < 7.10. Previously these would segfault.
-    
+
   * Remove useless accidental laziness in `atomicModifyMutVar`, making it match
     `atomicModifyIORef`. The semantics should be the same.
 
@@ -76,7 +78,7 @@
 
  * Fix the implementation of `mconcat` in the `Monoid` instance for
    `SmallArray`.
- 
+
  * Implement `Data.Primitive.Ptr`, implementations of `Ptr` functions
    that require a `Prim` constraint instead of a `Storable` constraint.
 

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -58,6 +58,8 @@ Library
   Build-Depends: base >= 4.5 && < 4.13
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
+  if !impl(ghc >= 8.0)
+    Build-Depends: fail == 4.9.*
 
   Ghc-Options: -O2
 


### PR DESCRIPTION
`base-4.13` will finally complete the `MonadFail` proposal by removing the `fail` method from `Monad`. This adapts `primitive` to that change by guarding the existing `fail` implementations in `primitive` (for `Array` and `SmallArray`) behind CPP, and defining `MonadFail` instances for `Array` and `SmallArray` going forward.