### PR TITLE
Bump base bounds

### DIFF
--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -43,7 +43,7 @@ benchmark bench
     PrimArray.Compare
     PrimArray.Traverse
   build-depends:
-      base >= 4.8 && < 4.13
+      base >= 4.8 && < 4.14
     , primitive
     , deepseq
     , ghc-prim

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -55,7 +55,7 @@ Library
         Data.Primitive.Internal.Compat
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.5 && < 4.13
+  Build-Depends: base >= 4.5 && < 4.14
                , ghc-prim >= 0.2 && < 0.6
                , transformers >= 0.2 && < 0.6
   if !impl(ghc >= 8.0)

--- a/test/primitive-tests.cabal
+++ b/test/primitive-tests.cabal
@@ -29,7 +29,7 @@ test-suite test
   hs-source-dirs: .
   main-is: main.hs
   type: exitcode-stdio-1.0
-  build-depends: base >= 4.5 && < 4.13
+  build-depends: base >= 4.5 && < 4.14
                , base-orphans
                , ghc-prim
                , primitive


### PR DESCRIPTION
This bumps the bounds so that `primitive` can be built with GHC 8.8.1 now that all is fixed. 