### PR TITLE
Remove Cabal flag hack in primitive-benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.2
+# version: 0.2.1
 #
 language: c
 dist: xenial
@@ -69,6 +69,7 @@ install:
   - echo "$(${HC} --version) [$(${HC} --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - TEST=--enable-tests
   - BENCH=--enable-benchmarks
+  - if [ $HCNUMVER -lt 71000 ] ; then BENCH=--disable-benchmarks ; fi
   - GHCHEAD=${GHCHEAD-false}
   - travis_retry ${CABAL} update -v
   - sed -i.bak 's/^jobs:/-- jobs:/' $CABALHOME/config
@@ -97,7 +98,7 @@ install:
   - touch cabal.project
   - "printf 'packages: \".\"\\n' >> cabal.project"
   - "printf 'packages: \"./test\"\\n' >> cabal.project"
-  - "printf 'packages: \"./bench\"\\n' >> cabal.project"
+  - "if [ $HCNUMVER -eq 71003 ]  ||  [ $HCNUMVER -eq 80002 ]  ||  [ $HCNUMVER -eq 80202 ]  ||  [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"./bench\"\\n' >> cabal.project ; fi"
   - echo 'package primitive' >> cabal.project
   - "echo '  ghc-options: -Wall' >> cabal.project"
   - echo 'package primitive-tests' >> cabal.project
@@ -130,7 +131,7 @@ script:
   - touch cabal.project
   - "printf 'packages: \"primitive-*/*.cabal\"\\n' >> cabal.project"
   - "printf 'packages: \"primitive-tests-*/*.cabal\"\\n' >> cabal.project"
-  - "printf 'packages: \"primitive-benchmarks-*/*.cabal\"\\n' >> cabal.project"
+  - "if [ $HCNUMVER -eq 71003 ]  ||  [ $HCNUMVER -eq 80002 ]  ||  [ $HCNUMVER -eq 80202 ]  ||  [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then printf 'packages: \"primitive-benchmarks-*/*.cabal\"\\n' >> cabal.project ; fi"
   - echo 'package primitive' >> cabal.project
   - "echo '  ghc-options: -Wall' >> cabal.project"
   - echo 'package primitive-tests' >> cabal.project
@@ -152,7 +153,7 @@ script:
   # cabal check
   - (cd primitive-* && ${CABAL} check)
   - (cd primitive-tests-* && ${CABAL} check)
-  - (cd primitive-benchmarks-* && ${CABAL} check)
+  - if [ $HCNUMVER -eq 71003 ]  ||  [ $HCNUMVER -eq 80002 ]  ||  [ $HCNUMVER -eq 80202 ]  ||  [ $HCNUMVER -eq 80404 ]  ||  [ $HCNUMVER -eq 80603 ] ; then (cd primitive-benchmarks-* && ${CABAL} check) ; fi
 
   # haddock
   - ${CABAL} new-haddock -w ${HC} ${TEST} ${BENCH} all

--- a/bench/primitive-benchmarks.cabal
+++ b/bench/primitive-benchmarks.cabal
@@ -15,22 +15,13 @@ Build-Type:     Simple
 Description:    @primitive@ benchmarks
 
 Tested-With:
-  GHC == 7.4.2,
-  GHC == 7.6.3,
-  GHC == 7.8.4,
   GHC == 7.10.3,
   GHC == 8.0.2,
   GHC == 8.2.2,
   GHC == 8.4.4,
   GHC == 8.6.3
 
-flag primitive-benchmarks
-  default: True
-
 benchmark bench
-  if !flag(primitive-benchmarks)
-    buildable: False
-
   Default-Language: Haskell2010
   hs-source-dirs: .
   main-is: main.hs

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,6 +1,8 @@
 ghc-head:               True
 jobs:                   2
+jobs-selection:         any
 no-tests-no-benchmarks: False
 unconstrained:          False
 install-dependencies:   False
 copy-fields:            all
+benchmarks:             >=7.10


### PR DESCRIPTION
It turns out that we can get away without needing an ugly Cabal flag in `primitive-benchmarks` by simply using `haskell-ci` more intelligently. I only added this flag in the first place since I was under the false impression that `haskell-ci` would _always_ pass the `--enable-benchmarks` flag if there was a benchmark suite, but I have since learned that that is not true.