### PR TITLE
Use GHC.Exts to import unsafeCoerce# et al.

### DIFF
--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -23,18 +23,9 @@ module Control.Monad.Primitive (
   touch, evalPrim, unsafeInterleave, unsafeDupableInterleave, noDuplicate
 ) where
 
-import GHC.Exts   ( State#, RealWorld, noDuplicate#, touch# )
-import GHC.Base   ( unsafeCoerce#, realWorld# )
-#if MIN_VERSION_base(4,4,0)
-import GHC.Base   ( seq# )
-#else
-import Control.Exception (evaluate)
-#endif
-#if MIN_VERSION_base(4,2,0)
+import GHC.Exts   ( State#, RealWorld, noDuplicate#, touch#
+                  , unsafeCoerce#, realWorld#, seq# )
 import GHC.IO     ( IO(..) )
-#else
-import GHC.IOBase ( IO(..) )
-#endif
 import GHC.ST     ( ST(..) )
 
 import Control.Monad.Trans.Class (lift)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
   * Add `Eq` instances for `MutableByteArray` and `MutablePrimArray`.
 
+  * Allow building with GHC 8.12.
+
 ## Changes in version 0.7.0.0
 
   * Remove `Addr` data type, lifted code should use `Ptr a` now


### PR DESCRIPTION
`unsafeCoerce#` can no longer be imported from `GHC.Base` on GHC HEAD, so this patch changes the import to `GHC.Exts` instead. While I was in town, I removed some unnecessary CPP (`primitive` supports GHC 7.4 as the minimum, so `MIN_VERSION_base(4,2,0)` and `MIN_VERSION_base(4,4,0)` are always true) and consolidated some other `GHC.Base` imports to use `GHC.Exts` instead.

Fixes #258.