### PR TITLE
Ensure that HsFFI.h is #include'd first

### DIFF
--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -1,9 +1,11 @@
 #ifndef haskell_primitive_memops_h
 #define haskell_primitive_memops_h
 
+// N.B. GHC RTS headers want to come first, lest things break on Windows.
+#include <HsFFI.h>
+
 #include <stdlib.h>
 #include <stddef.h>
-#include <HsFFI.h>
 
 void hsprimitive_memcpy( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
 void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );


### PR DESCRIPTION
Otherwise things may break on Windows. For instance,
you may get things like,
```
   includes\stg\Types.h:26:9: error:
     warning: #warning "Mismatch between __USE_MINGW_ANSI_STDIO
     definitions. If using Rts.h make sure it is the first header
     included." [-Wcpp]
```