### PR TITLE
Add NFData instances for Array and SmallArray

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -27,6 +27,7 @@ module Data.Primitive.Array (
   traverseArrayP
 ) where
 
+import Control.DeepSeq
 import Control.Monad.Primitive
 
 import GHC.Base  ( Int(..) )
@@ -50,6 +51,7 @@ import Control.Applicative
 import Control.Monad (MonadPlus(..), when)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
+import qualified Data.Foldable as Foldable
 #if MIN_VERSION_base(4,4,0)
 import Control.Monad.Zip
 #endif
@@ -86,6 +88,14 @@ import Control.Monad (liftM2)
 data Array a = Array
   { array# :: Array# a }
   deriving ( Typeable )
+
+#if MIN_VERSION_deepseq(1,4,3)
+instance NFData1 Array where
+  liftRnf r = Foldable.foldl' (\_ -> r) ()
+#endif
+
+instance NFData a => NFData (Array a) where
+  rnf = Foldable.foldl' (\_ -> rnf) ()
 
 -- | Mutable boxed arrays associated with a primitive state token.
 data MutableArray s a = MutableArray

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -73,6 +73,7 @@ import qualified GHC.Exts
 #endif
 
 import Control.Applicative
+import Control.DeepSeq
 import Control.Monad
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
@@ -125,6 +126,10 @@ newtype SmallArray a = SmallArray (Array a) deriving
   , MonadZip
   , MonadFix
   , Monoid
+  , NFData
+#if MIN_VERSION_deepseq(1,4,3)
+  , NFData1
+#endif
   , Typeable
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
   , Eq1
@@ -141,6 +146,16 @@ instance IsList (SmallArray a) where
   fromList l = SmallArray (fromList l)
   toList a = Foldable.toList a
 #endif
+#endif
+
+#if HAVE_SMALL_ARRAY
+#if MIN_VERSION_deepseq(1,4,3)
+instance NFData1 SmallArray where
+  liftRnf r = foldl' (\_ -> r) ()
+#endif
+
+instance NFData a => NFData (SmallArray a) where
+  rnf = foldl' (\_ -> rnf) ()
 #endif
 
 #if HAVE_SMALL_ARRAY

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@
     `PrimArray` and `MutablePrimArray`.
     by Callan McGill
 
+  * Add `NFData` instances for `Array` and `SmallArray`.
+    by Callan McGill
+
 ## Changes in version 0.7.0.1
 
   * Allow building with GHC 8.12.


### PR DESCRIPTION
This adds `NFData` instances for `Array` and `SmallArray` as suggested by @andrewthad. I'm not too familiar with using CPP for supporting many versions so I'm happy to fix glaring errors. 