### PR TITLE
remove fundep on MonadPrim

### DIFF
--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -233,7 +233,7 @@ instance PrimBase (L.ST s) where
 --   in constraints. This typeclass lets users (visually) notice
 --   'PrimState' equality constraints less, by witnessing that
 --   @s ~ 'PrimState' m@.
-class (PrimMonad m, s ~ PrimState m) => MonadPrim s m | m -> s
+class (PrimMonad m, s ~ PrimState m) => MonadPrim s m
 instance (PrimMonad m, s ~ PrimState m) => MonadPrim s m
 
 -- | 'PrimBase''s state token type can be annoying to handle

--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts, FlexibleInstances, UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 -- |


### PR DESCRIPTION
cc @emilypi @treeowl 

I think we just auto-fundep'd based on MTL. it is indeed unnecessary.