### PR TITLE
Bump upper bounds on base

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -53,7 +53,7 @@ Library
         Data.Primitive.Internal.Compat
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.5 && < 4.15
+  Build-Depends: base >= 4.5 && < 4.16
                , deepseq >= 1.1 && < 1.5
                , transformers >= 0.2 && < 0.6
   if !impl(ghc >= 8.0)


### PR DESCRIPTION
Bump upper bound to build with `ghc-9.0`.