### PR TITLE
Support GHC 9.2

### DIFF
--- a/Data/Primitive/Internal/Operations.hs
+++ b/Data/Primitive/Internal/Operations.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash, UnliftedFFITypes #-}
+{-# LANGUAGE CPP, MagicHash, UnliftedFFITypes #-}
 
 -- |
 -- Module      : Data.Primitive.Internal.Operations
@@ -32,26 +32,49 @@ import Data.Primitive.MachDeps (Word64_#, Int64_#)
 import Foreign.C.Types
 import GHC.Exts
 
+
+#if __GLASGOW_HASKELL__ >= 902
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+  setWord8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word8# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+  setWord16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word16# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+  setWord32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word32# -> IO ()
+#else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setWord8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
   setWord16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setWord32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
+#endif
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"
   setWord64Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word64_# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setWordArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
+
+#if __GLASGOW_HASKELL__ >= 902
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+  setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int8# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+  setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int16# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+  setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
+#else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
   setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+#endif
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"
   setInt64Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int64_# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setIntArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
   setAddrArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Addr# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
@@ -63,26 +86,48 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Double"
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Char"
   setWideCharArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Char# -> IO ()
 
+#if __GLASGOW_HASKELL__ >= 902
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+  setWord8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word8# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+  setWord16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word16# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+  setWord32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word32# -> IO ()
+#else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setWord8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
   setWord16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setWord32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
+#endif
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"
   setWord64OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word64_# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setWordOffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
+
+#if __GLASGOW_HASKELL__ >= 902
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+  setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int8# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+  setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int16# -> IO ()
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+  setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
+#else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
   setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+#endif
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"
   setInt64OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int64_# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setIntOffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"
   setAddrOffAddr# :: Addr# -> CPtrdiff -> CSize -> Addr# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Ptr"

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -250,7 +250,14 @@ instance Prim (ty) where {                                      \
 ; {-# INLINE setOffAddr# #-}                                    \
 }
 
-#if __GLASGOW_HASKELL__ >= 710
+#if __GLASGOW_HASKELL__ >= 902
+liberate# :: State# s -> State# r
+liberate# = unsafeCoerce#
+shimmedSetWord8Array# :: MutableByteArray# s -> Int -> Int -> Word8# -> IO ()
+shimmedSetWord8Array# m (I# off) (I# len) w = IO (\s -> (# liberate# (GHC.Exts.setByteArray# m off len (GHC.Exts.word2Int# (GHC.Exts.word8ToWord# w)) (liberate# s)), () #))
+shimmedSetInt8Array# :: MutableByteArray# s -> Int -> Int -> Int8# -> IO ()
+shimmedSetInt8Array# m (I# off) (I# len) i = IO (\s -> (# liberate# (GHC.Exts.setByteArray# m off len (GHC.Exts.int8ToInt# i) (liberate# s)), () #))
+#elif __GLASGOW_HASKELL__ >= 710
 liberate# :: State# s -> State# r
 liberate# = unsafeCoerce#
 shimmedSetWord8Array# :: MutableByteArray# s -> Int -> Int -> Word# -> IO ()

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -421,8 +421,8 @@ deriving instance Prim Fd
 
 -- | @since 0.7.1.0
 instance Prim WordPtr where
-  sizeOf# _ = sizeOf# (undefined :: Ptr ()) 
-  alignment# _ = alignment# (undefined :: Ptr ()) 
+  sizeOf# _ = sizeOf# (undefined :: Ptr ())
+  alignment# _ = alignment# (undefined :: Ptr ())
   indexByteArray# a i = ptrToWordPtr (indexByteArray# a i)
   readByteArray# a i s0 = case readByteArray# a i s0 of
     (# s1, p #) -> (# s1, ptrToWordPtr p #)
@@ -433,11 +433,11 @@ instance Prim WordPtr where
     (# s1, p #) -> (# s1, ptrToWordPtr p #)
   writeOffAddr# a i wp = writeOffAddr# a i (wordPtrToPtr wp)
   setOffAddr# a i n wp = setOffAddr# a i n (wordPtrToPtr wp)
-  
+
 -- | @since 0.7.1.0
 instance Prim IntPtr where
-  sizeOf# _ = sizeOf# (undefined :: Ptr ()) 
-  alignment# _ = alignment# (undefined :: Ptr ()) 
+  sizeOf# _ = sizeOf# (undefined :: Ptr ())
+  alignment# _ = alignment# (undefined :: Ptr ())
   indexByteArray# a i = ptrToIntPtr (indexByteArray# a i)
   readByteArray# a i s0 = case readByteArray# a i s0 of
     (# s1, p #) -> (# s1, ptrToIntPtr p #)

--- a/cbits/primitive-memops.c
+++ b/cbits/primitive-memops.c
@@ -45,14 +45,14 @@ int hsprimitive_memcmp_offset( HsWord8 *s1, HsInt off1, HsWord8 *s2, HsInt off2,
   return memcmp( s1 + off1, s2 + off2, n );
 }
 
-void hsprimitive_memset_Word8 (HsWord8 *p, ptrdiff_t off, size_t n, HsWord x)
+void hsprimitive_memset_Word8 (HsWord8 *p, ptrdiff_t off, size_t n, HsWord8 x)
 {
   memset( (char *)(p+off), x, n );
 }
 
 /* MEMSET(HsWord8, HsWord) */
-MEMSET(Word16, HsWord)
-MEMSET(Word32, HsWord)
+MEMSET(Word16, HsWord16)
+MEMSET(Word32, HsWord32)
 MEMSET(Word64, HsWord64)
 MEMSET(Word, HsWord)
 MEMSET(Ptr, HsPtr)

--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -12,9 +12,9 @@ void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, 
 int  hsprimitive_memcmp( HsWord8 *s1, HsWord8 *s2, size_t n );
 int  hsprimitive_memcmp_offset( HsWord8 *s1, HsInt off1, HsWord8 *s2, HsInt off2, size_t n );
 
-void hsprimitive_memset_Word8 (HsWord8 *, ptrdiff_t, size_t, HsWord);
-void hsprimitive_memset_Word16 (HsWord16 *, ptrdiff_t, size_t, HsWord);
-void hsprimitive_memset_Word32 (HsWord32 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word8 (HsWord8 *, ptrdiff_t, size_t, HsWord8);
+void hsprimitive_memset_Word16 (HsWord16 *, ptrdiff_t, size_t, HsWord16);
+void hsprimitive_memset_Word32 (HsWord32 *, ptrdiff_t, size_t, HsWord32);
 void hsprimitive_memset_Word64 (HsWord64 *, ptrdiff_t, size_t, HsWord64);
 void hsprimitive_memset_Word (HsWord *, ptrdiff_t, size_t, HsWord);
 void hsprimitive_memset_Ptr (HsPtr *, ptrdiff_t, size_t, HsPtr);


### PR DESCRIPTION
Hi there,

I gave it a shot at fixing #302. This is all pretty naive as I am still not very familiar with GHC primitives. It compiles and passes tests on GHC 8.8, GHC 8.10, GHC 9.0. For GHC 9.2 I haven't managed to run the tests yet because the `bifunctor` doesn't compile on GHC 9.2 (due to some changes to `template-haskell`). I might do some manual testing.
