### PR TITLE
Add thawByteArray, thawPrimArray

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -41,7 +41,7 @@ module Data.Primitive.ByteArray (
   compareByteArrays,
 
   -- * Freezing and thawing
-  freezeByteArray,
+  freezeByteArray, thawByteArray,
   unsafeFreezeByteArray, unsafeThawByteArray,
 
   -- * Block operations
@@ -231,6 +231,23 @@ freezeByteArray !src !off !len = do
   dst <- newByteArray len
   copyMutableByteArray dst 0 src off len
   unsafeFreezeByteArray dst
+
+-- | Create a mutable byte array from a slice of an immutable byte array.
+-- The offset and length are given in bytes.
+--
+-- This operation makes a copy of the specified slice, so it is safe to
+-- use the immutable array afterward.
+thawByteArray
+  :: PrimMonad m
+  => ByteArray -- ^ source
+  -> Int       -- ^ offset in bytes
+  -> Int       -- ^ length in bytes
+  -> m (MutableByteArray (PrimState m))
+{-# INLINE thawByteArray #-}
+thawByteArray !src !off !len = do
+  dst <- newByteArray len
+  copyByteArray dst 0 src off len
+  return dst
 
 -- | Convert a mutable byte array to an immutable one without copying. The
 -- array should not be modified after the conversion.

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -237,6 +237,8 @@ freezeByteArray !src !off !len = do
 --
 -- This operation makes a copy of the specified slice, so it is safe to
 -- use the immutable array afterward.
+--
+-- @since 0.7.2.0
 thawByteArray
   :: PrimMonad m
   => ByteArray -- ^ source

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -508,6 +508,8 @@ freezePrimArray !src !off !len = do
 --
 -- This operation makes a copy of the specified slice, so it is safe to
 -- use the immutable array afterward.
+--
+-- @since 0.7.2.0
 thawPrimArray
   :: (PrimMonad m, Prim a)
   => PrimArray a -- ^ source

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## Changes in version 0.7.2.0
+
+  * Add `thawByteArray` and `thawPrimArray`.
+
 ## Changes in version 0.7.1.0
 
   * Introduce convenience class `MonadPrim` and `MonadPrimBase`.


### PR DESCRIPTION
Fixes #307.

I added `thawByteArray` and `thawPrimArray`. The implementation is just new + copy, similar to the respective freeze variant. The doc comments are essentially copied from `thawArray`.
I also fixed some typos in `Data.PrimArray` that i noticed, where "byte" was used instead of "primitive"/"prim".