### PR TITLE
Zero-pad words encoded in ByteArray Show instance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,8 @@
 
   * Add `thawByteArray` and `thawPrimArray`.
 
-  * Changed the `Show` instance of `ByteArray` so that all 8-bit words
-    are rendered as two digits. For example, display `0x0D` instead of `0xD`
-    for as an element.
+  * Changed the `Show` instance of `ByteArray`, so that all 8-bit words
+    are rendered as two digits. For example, display `0x0D` instead of `0xD`.
 
 ## Changes in version 0.7.1.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
   * Add `thawByteArray` and `thawPrimArray`.
 
+  * Changed the `Show` instance of `ByteArray` so that all 8-bit words
+    are rendered as two digits. For example, display `0x0D` instead of `0xD`
+    for as an element.
+
 ## Changes in version 0.7.1.0
 
   * Introduce convenience class `MonadPrim` and `MonadPrimBase`.

--- a/test/main.hs
+++ b/test/main.hs
@@ -357,8 +357,11 @@ testByteArray = do
         arr3 = mkByteArray ([0xde, 0xad, 0xbe, 0xee] :: [Word8])
         arr4 = mkByteArray ([0xde, 0xad, 0xbe, 0xdd] :: [Word8])
         arr5 = mkByteArray ([0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xdd] :: [Word8])
+        arr6 = mkByteArray ([0xde, 0xad, 0x00, 0x01, 0xb0] :: [Word8])
     when (show arr1 /= "[0xde, 0xad, 0xbe, 0xef]") $
         fail $ "ByteArray Show incorrect: "++show arr1
+    when (show arr6 /= "[0xde, 0xad, 0x00, 0x01, 0xb0]") $
+        fail $ "ByteArray Show incorrect: "++ show arr6
     when (compareByteArrays arr3 1 arr4 1 3 /= GT) $
         fail $ "arr3[1,3] should be greater than arr4[1,3]"
     when (compareByteArrays arr3 0 arr4 1 3 /= GT) $


### PR DESCRIPTION
Previously, the Show instance for ByteArray would produce results like [0xb, 0x1f, 0x5]. Now, it produces [0x0b, 0x1f, 0x05].