### PR TITLE
Fix bugs in `*>`

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -672,33 +672,36 @@ instance Functor Array where
 
 instance Applicative Array where
   pure x = runArray $ newArray 1 x
-  ab <*> a = createArray (szab*sza) (die "<*>" "impossible") $ \mb ->
+
+  ab <*> a = createArray (szab * sza) (die "<*>" "impossible") $ \mb ->
     let go1 i = when (i < szab) $
             do
               f <- indexArrayM ab i
-              go2 (i*sza) f 0
-              go1 (i+1)
+              go2 (i * sza) f 0
+              go1 (i + 1)
         go2 off f j = when (j < sza) $
             do
               x <- indexArrayM a j
               writeArray mb (off + j) (f x)
               go2 off f (j + 1)
     in go1 0
-   where szab = sizeofArray ab ; sza = sizeofArray a
-  a *> b = createArray (sza*szb) (die "*>" "impossible") $ \mb ->
-    let go i | i < sza   = copyArray mb (i * szb) b 0 szb
+   where szab = sizeofArray ab; sza = sizeofArray a
+
+  a *> b = createArray (sza * szb) (die "*>" "impossible") $ \mb ->
+    let go i | i < sza   = copyArray mb (i * szb) b 0 szb *> go (i + 1)
              | otherwise = return ()
-     in go 0
-   where sza = sizeofArray a ; szb = sizeofArray b
-  a <* b = createArray (sza*szb) (die "<*" "impossible") $ \ma ->
-    let fill off i e | i < szb   = writeArray ma (off+i) e >> fill off (i+1) e
+    in go 0
+   where sza = sizeofArray a; szb = sizeofArray b
+
+  a <* b = createArray (sza * szb) (die "<*" "impossible") $ \ma ->
+    let fill off i e | i < szb   = writeArray ma (off + i) e >> fill off (i + 1) e
                      | otherwise = return ()
         go i | i < sza
              = do x <- indexArrayM a i
-                  fill (i*szb) 0 x >> go (i+1)
+                  fill (i * szb) 0 x >> go (i + 1)
              | otherwise = return ()
-     in go 0
-   where sza = sizeofArray a ; szb = sizeofArray b
+    in go 0
+   where sza = sizeofArray a; szb = sizeofArray b
 
 instance Alternative Array where
   empty = emptyArray

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -764,36 +764,36 @@ instance Functor SmallArray where
 instance Applicative SmallArray where
   pure x = createSmallArray 1 x noOp
 
-  sa *> sb = createSmallArray (la*lb) (die "*>" "impossible") $ \smb ->
+  sa *> sb = createSmallArray (la * lb) (die "*>" "impossible") $ \smb ->
     fix ? 0 $ \go i ->
       when (i < la) $
-        copySmallArray smb 0 sb 0 lb *> go (i+1)
+        copySmallArray smb (i * lb) sb 0 lb *> go (i + 1)
    where
-   la = length sa ; lb = length sb
+    la = length sa; lb = length sb
 
-  a <* b = createSmallArray (sza*szb) (die "<*" "impossible") $ \ma ->
+  a <* b = createSmallArray (sza * szb) (die "<*" "impossible") $ \ma ->
     let fill off i e = when (i < szb) $
-                         writeSmallArray ma (off+i) e >> fill off (i+1) e
+                         writeSmallArray ma (off + i) e >> fill off (i + 1) e
         go i = when (i < sza) $ do
                  x <- indexSmallArrayM a i
-                 fill (i*szb) 0 x
-                 go (i+1)
+                 fill (i * szb) 0 x
+                 go (i + 1)
      in go 0
-   where sza = sizeofSmallArray a ; szb = sizeofSmallArray b
+   where sza = sizeofSmallArray a; szb = sizeofSmallArray b
 
-  ab <*> a = createSmallArray (szab*sza) (die "<*>" "impossible") $ \mb ->
+  ab <*> a = createSmallArray (szab * sza) (die "<*>" "impossible") $ \mb ->
     let go1 i = when (i < szab) $
             do
               f <- indexSmallArrayM ab i
-              go2 (i*sza) f 0
-              go1 (i+1)
+              go2 (i * sza) f 0
+              go1 (i + 1)
         go2 off f j = when (j < sza) $
             do
               x <- indexSmallArrayM a j
               writeSmallArray mb (off + j) (f x)
               go2 off f (j + 1)
     in go1 0
-   where szab = sizeofSmallArray ab ; sza = sizeofSmallArray a
+   where szab = sizeofSmallArray ab; sza = sizeofSmallArray a
 
 instance Alternative SmallArray where
   empty = emptySmallArray

--- a/test/main.hs
+++ b/test/main.hs
@@ -81,6 +81,8 @@ main = do
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy (Array Int)))
       , TQC.testProperty "mapArray'" (QCCL.mapProp int16 int32 mapArray')
 #endif
+      , TQC.testProperty "*>" $ \(xs :: Array Int) (ys :: Array Int) -> toList (xs *> ys) === (toList xs *> toList ys)
+      , TQC.testProperty "<*" $ \(xs :: Array Int) (ys :: Array Int) -> toList (xs <* ys) === (toList xs <* toList ys)
       ]
     , testGroup "SmallArray"
       [ lawsToTest (QCC.eqLaws (Proxy :: Proxy (SmallArray Int)))
@@ -98,6 +100,8 @@ main = do
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy (SmallArray Int)))
       , TQC.testProperty "mapSmallArray'" (QCCL.mapProp int16 int32 mapSmallArray')
 #endif
+      , TQC.testProperty "*>" $ \(xs :: SmallArray Int) (ys :: SmallArray Int) -> toList (xs *> ys) === (toList xs *> toList ys)
+      , TQC.testProperty "<*" $ \(xs :: SmallArray Int) (ys :: SmallArray Int) -> toList (xs <* ys) === (toList xs <* toList ys)
       ]
     , testGroup "ByteArray"
       [ testGroup "Ordering"
@@ -159,18 +163,15 @@ main = do
       , TQC.testProperty "mapMaybePrimArrayP" (QCCL.mapMaybeMProp int16 int32 mapMaybePrimArrayP)
 #endif
       ]
-
-
-
-     ,testGroup "DefaultSetMethod"
+    , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
       ]
 #if __GLASGOW_HASKELL__ >= 805
-    ,testGroup "PrimStorable"
+    , testGroup "PrimStorable"
       [ lawsToTest (QCC.storableLaws (Proxy :: Proxy Derived))
       ]
 #endif
-     ,testGroup "Prim"
+    , testGroup "Prim"
       [ renameLawsToTest "Word" (primLaws (Proxy :: Proxy Word))
       , renameLawsToTest "Word8" (primLaws (Proxy :: Proxy Word8))
       , renameLawsToTest "Word16" (primLaws (Proxy :: Proxy Word16))
@@ -195,9 +196,7 @@ main = do
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
 #endif
-
       ]
-
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)


### PR DESCRIPTION
The implementations of `*>` for `Array` and `SmallArray` were buggy:

* `Array`: The bug was caused by not calling `go (i + 1)`.
* `SmallArray`: The bug was caused by using `0` instead of `i * lb` as offset when calling `copySmallArray` in the implementation of `*>`.

I also did some minor formatting changes.

Btw, is there any particular reason for using `fix` instead of defining a recursive `go` function directly?