### PR TITLE
Improve documentation & format

### DIFF
--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -78,7 +78,7 @@ class Monad m => PrimMonad m where
 
 -- | Class of primitive monads for state-transformer actions.
 --
--- Unlike 'PrimMonad', this typeclass requires the @Monad@ to be fully
+-- Unlike 'PrimMonad', this typeclass requires that the @Monad@ be fully
 -- expressed as a state transformer, therefore disallowing other monad
 -- transformers on top of the base @IO@ or @ST@.
 --

--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -12,8 +12,7 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Primitive state-transformer monads
---
+-- Primitive state-transformer monads.
 
 module Control.Monad.Primitive (
   PrimMonad(..), RealWorld, primitive_,
@@ -69,26 +68,26 @@ import qualified Control.Monad.Trans.RWS.Strict    as Strict ( RWST   )
 import qualified Control.Monad.Trans.State.Strict  as Strict ( StateT )
 import qualified Control.Monad.Trans.Writer.Strict as Strict ( WriterT )
 
--- | Class of monads which can perform primitive state-transformer actions
+-- | Class of monads which can perform primitive state-transformer actions.
 class Monad m => PrimMonad m where
-  -- | State token type
+  -- | State token type.
   type PrimState m
 
-  -- | Execute a primitive operation
+  -- | Execute a primitive operation.
   primitive :: (State# (PrimState m) -> (# State# (PrimState m), a #)) -> m a
 
 -- | Class of primitive monads for state-transformer actions.
 --
--- Unlike 'PrimMonad', this typeclass requires that the @Monad@ be fully
+-- Unlike 'PrimMonad', this typeclass requires the @Monad@ to be fully
 -- expressed as a state transformer, therefore disallowing other monad
 -- transformers on top of the base @IO@ or @ST@.
 --
 -- @since 0.6.0.0
 class PrimMonad m => PrimBase m where
-  -- | Expose the internal structure of the monad
+  -- | Expose the internal structure of the monad.
   internal :: m a -> State# (PrimState m) -> (# State# (PrimState m), a #)
 
--- | Execute a primitive operation with no result
+-- | Execute a primitive operation with no result.
 primitive_ :: PrimMonad m
               => (State# (PrimState m) -> State# (PrimState m)) -> m ()
 {-# INLINE primitive_ #-}
@@ -100,6 +99,7 @@ instance PrimMonad IO where
   type PrimState IO = RealWorld
   primitive = IO
   {-# INLINE primitive #-}
+
 instance PrimBase IO where
   internal (IO p) = p
   {-# INLINE internal #-}
@@ -189,6 +189,7 @@ instance ( Monoid w
   type PrimState (AccumT w m) = PrimState m
   primitive = lift . primitive
   {-# INLINE primitive #-}
+
 instance PrimMonad m => PrimMonad (SelectT r m) where
   type PrimState (SelectT r m) = PrimState m
   primitive = lift . primitive
@@ -214,6 +215,7 @@ instance PrimMonad (ST s) where
   type PrimState (ST s) = s
   primitive = ST
   {-# INLINE primitive #-}
+
 instance PrimBase (ST s) where
   internal (ST p) = p
   {-# INLINE internal #-}

--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MagicHash #-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports #-}
+
 -- |
 -- Module      : Data.Primitive
 -- Copyright   : (c) Roman Leshchinskiy 2009-2012
@@ -8,16 +9,16 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Reexports all primitive operations
---
+-- Reexports all primitive operations.
+
 module Data.Primitive (
   -- * Re-exports
-  module Data.Primitive.Types
-  ,module Data.Primitive.Array
-  ,module Data.Primitive.ByteArray
-  ,module Data.Primitive.SmallArray
-  ,module Data.Primitive.PrimArray
-  ,module Data.Primitive.MutVar
+  module Data.Primitive.Types,
+  module Data.Primitive.Array,
+  module Data.Primitive.ByteArray,
+  module Data.Primitive.SmallArray,
+  module Data.Primitive.PrimArray,
+  module Data.Primitive.MutVar
   -- * Naming Conventions
   -- $namingConventions
 ) where
@@ -39,21 +40,22 @@ of the variants of the array indexing function are:
 > indexPrimArray  :: Prim a => PrimArray  a -> Int -> a
 
 In a few places, where the language sounds more natural, the array type
-is instead used as a prefix. For example, @Data.Primitive.SmallArray@
-exports @smallArrayFromList@, which would sound unnatural if it used
+is instead used as a prefix. For example, "Data.Primitive.SmallArray"
+exports 'smallArrayFromList', which would sound unnatural if it used
 @SmallArray@ as a suffix instead.
 
-This library provides several functions traversing, building, and filtering
+This library provides several functions for traversing, building, and filtering
 arrays. These functions are suffixed with an additional character to
-indicate their the nature of their effectfulness:
+indicate the nature of their effectfulness:
 
 * No suffix: A non-effectful pass over the array.
-* @-A@ suffix: An effectful pass over the array, where the effect is 'Applicative'.
-* @-P@ suffix: An effectful pass over the array, where the effect is 'PrimMonad'.
+* @A@ suffix: An effectful pass over the array, where the effect is 'Applicative'.
+* @P@ suffix: An effectful pass over the array, where the effect is 'Control.Monad.Primitive.PrimMonad'.
 
 Additionally, an apostrophe can be used to indicate strictness in the elements.
-The variants with an apostrophe are used in @Data.Primitive.Array@ but not
-in @Data.Primitive.PrimArray@ since the array type it provides is always strict in the element.
+The variants with an apostrophe are used in "Data.Primitive.Array" but not
+in "Data.Primitive.PrimArray" since the array type it provides is always strict in the element anyway.
+
 For example, there are three variants of the function that filters elements
 from a primitive array.
 
@@ -61,17 +63,17 @@ from a primitive array.
 > filterPrimArrayA :: (Prim a, Applicative f) => (a -> f Bool) -> PrimArray a -> f (PrimArray a)
 > filterPrimArrayP :: (Prim a, PrimMonad   m) => (a -> m Bool) -> PrimArray a -> m (PrimArray a)
 
-As long as the effectful context is a monad that is sufficiently affine
-the behaviors of the 'Applicative' and 'PrimMonad' variants produce the same results
-and differ only in their strictness. Monads that are sufficiently affine
-include:
+As long as the effectful context is a monad that is sufficiently affine,
+the behaviors of the 'Applicative' and 'Control.Monad.Primitive.PrimMonad'
+variants produce the same results and differ only in their strictness.
+Monads that are sufficiently affine include:
 
 * 'IO' and 'ST'
 * Any combination of 'MaybeT', 'ExceptT', 'StateT' and 'Writer' on top
   of another sufficiently affine monad.
-* Any Monad which does not include backtracking or other mechanism where an effect can
-happen more than once is an Affine Monad in the sense we care about. ContT, LogicT, ListT are all
-examples of search/control monads which are NOT affine: they can run a sub computation more than once.
+* Any Monad which does not include backtracking or other mechanisms where an effect can
+  happen more than once is an affine Monad in the sense we care about. @ContT@, @LogicT@, @ListT@ are all
+  examples of search/control monads which are NOT affine: they can run a sub computation more than once.
 
 There is one situation where the names deviate from effectful suffix convention
 described above. Throughout the haskell ecosystem, the 'Applicative' variant of

--- a/Data/Primitive.hs
+++ b/Data/Primitive.hs
@@ -11,17 +11,17 @@
 --
 -- Reexports all primitive operations.
 
-module Data.Primitive (
-  -- * Re-exports
-  module Data.Primitive.Types,
-  module Data.Primitive.Array,
-  module Data.Primitive.ByteArray,
-  module Data.Primitive.SmallArray,
-  module Data.Primitive.PrimArray,
-  module Data.Primitive.MutVar
+module Data.Primitive
+  ( -- * Re-exports
+    module Data.Primitive.Types
+  , module Data.Primitive.Array
+  , module Data.Primitive.ByteArray
+  , module Data.Primitive.SmallArray
+  , module Data.Primitive.PrimArray
+  , module Data.Primitive.MutVar
   -- * Naming Conventions
   -- $namingConventions
-) where
+  ) where
 
 import Data.Primitive.Types
 import Data.Primitive.Array

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -583,7 +583,7 @@ traverseArray f = \ !ary ->
 -- | This is the fastest, most straightforward way to traverse
 -- an array, but it only works correctly with a sufficiently
 -- "affine" 'PrimMonad' instance. In particular, it must only produce
--- __one__ result array. 'Control.Monad.Trans.List.ListT'-transformed
+-- /one/ result array. 'Control.Monad.Trans.List.ListT'-transformed
 -- monads, for example, will not work right at all.
 traverseArrayP
   :: PrimMonad m

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -11,7 +11,6 @@
 -- Portability : non-portable
 --
 -- Primitive arrays of boxed values.
---
 
 module Data.Primitive.Array (
   Array(..), MutableArray(..),
@@ -31,27 +30,22 @@ module Data.Primitive.Array (
 
 import Control.DeepSeq
 import Control.Monad.Primitive
-import Data.Data (mkNoRepType)
 
-import GHC.Base  ( Int(..) )
 import GHC.Exts
 #if (MIN_VERSION_base(4,7,0))
   hiding (toList)
 #endif
 import qualified GHC.Exts as Exts
-#if (MIN_VERSION_base(4,7,0))
-import GHC.Exts (fromListN, fromList)
-#endif
 
 import Data.Typeable ( Typeable )
 import Data.Data
-  (Data(..), DataType, mkDataType, Constr, mkConstr, Fixity(..), constrIndex)
-import Data.Primitive.Internal.Compat ( isTrue# )
+  (Data(..), DataType, mkDataType, mkNoRepType, Constr, mkConstr, Fixity(..), constrIndex)
+import Data.Primitive.Internal.Compat (isTrue#)
 
-import Control.Monad.ST(ST,runST)
+import Control.Monad.ST (ST, runST)
 
 import Control.Applicative
-import Control.Monad (MonadPlus(..), when)
+import Control.Monad (MonadPlus(..), when, liftM2)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad.Fix
 import qualified Data.Foldable as Foldable
@@ -83,11 +77,10 @@ import qualified Text.ParserCombinators.ReadPrec as RdPrc
 import Text.ParserCombinators.ReadP
 
 #if MIN_VERSION_base(4,9,0) || MIN_VERSION_transformers(0,4,0)
-import Data.Functor.Classes (Eq1(..),Ord1(..),Show1(..),Read1(..))
+import Data.Functor.Classes (Eq1(..), Ord1(..), Show1(..), Read1(..))
 #endif
-import Control.Monad (liftM2)
 
--- | Boxed arrays
+-- | Boxed arrays.
 data Array a = Array
   { array# :: Array# a }
   deriving ( Typeable )
@@ -105,10 +98,12 @@ data MutableArray s a = MutableArray
   { marray# :: MutableArray# s a }
   deriving ( Typeable )
 
+-- | The number of elements in an immutable array.
 sizeofArray :: Array a -> Int
 sizeofArray a = I# (sizeofArray# (array# a))
 {-# INLINE sizeofArray #-}
 
+-- | The number of elements in a mutable array.
 sizeofMutableArray :: MutableArray s a -> Int
 sizeofMutableArray a = I# (sizeofMutableArray# (marray# a))
 {-# INLINE sizeofMutableArray #-}
@@ -164,7 +159,7 @@ indexArray## arr (I# i) = indexArray# (array# arr) i
 -- >                        writeArray marr i (indexArray arr i) ...
 -- >                        ...
 --
--- But since primitive arrays are lazy, the calls to 'indexArray' will not be
+-- But since the arrays are lazy, the calls to 'indexArray' will not be
 -- evaluated. Rather, @marr@ will be filled with thunks each of which would
 -- retain a reference to @arr@. This is definitely not what we want!
 --
@@ -188,6 +183,9 @@ indexArrayM arr (I# i#)
 --
 -- This operation makes a copy of the specified section, so it is safe to
 -- continue using the mutable array afterward.
+--
+-- /Note:/ The provided array should contain the full subrange
+-- specified by the two Ints, but this is not checked.
 freezeArray
   :: PrimMonad m
   => MutableArray (PrimState m) a -- ^ source
@@ -213,6 +211,9 @@ unsafeFreezeArray arr
 --
 -- This operation makes a copy of the specified slice, so it is safe to use the
 -- immutable array afterward.
+--
+-- /Note:/ The provided array should contain the full subrange
+-- specified by the two Ints, but this is not checked.
 thawArray
   :: PrimMonad m
   => Array a -- ^ source
@@ -259,18 +260,15 @@ copyArray (MutableArray dst#) (I# doff#) (Array src#) (I# soff#) (I# len#)
 copyArray !dst !doff !src !soff !len = go 0
   where
     go i | i < len = do
-                       x <- indexArrayM src (soff+i)
-                       writeArray dst (doff+i) x
-                       go (i+1)
+                       x <- indexArrayM src (soff + i)
+                       writeArray dst (doff + i) x
+                       go (i + 1)
          | otherwise = return ()
 #endif
 
 -- | Copy a slice of a mutable array to another array. The two arrays must
 -- not be the same when using this library with GHC versions 7.6 and older.
 -- In GHC 7.8 and newer, overlapping arrays will behave correctly.
---
--- /Note:/ The order of arguments is different from that of 'copyMutableArray#'. The primop
--- has the source first while this wrapper has the destination first.
 --
 -- /Note:/ this function does not do bounds or overlap checking.
 copyMutableArray :: PrimMonad m
@@ -290,16 +288,16 @@ copyMutableArray (MutableArray dst#) (I# doff#)
 copyMutableArray !dst !doff !src !soff !len = go 0
   where
     go i | i < len = do
-                       x <- readArray src (soff+i)
-                       writeArray dst (doff+i) x
-                       go (i+1)
+                       x <- readArray src (soff + i)
+                       writeArray dst (doff + i) x
+                       go (i + 1)
          | otherwise = return ()
 #endif
 
--- | Return a newly allocated Array with the specified subrange of the
--- provided Array.
+-- | Return a newly allocated 'Array' with the specified subrange of the
+-- provided 'Array'.
 --
--- /Note:/ The provided Array should contain the full subrange
+-- /Note:/ The provided array should contain the full subrange
 -- specified by the two Ints, but this is not checked.
 cloneArray :: Array a -- ^ source array
            -> Int     -- ^ offset into destination array
@@ -309,11 +307,11 @@ cloneArray :: Array a -- ^ source array
 cloneArray (Array arr#) (I# off#) (I# len#)
   = case cloneArray# arr# off# len# of arr'# -> Array arr'#
 
--- | Return a newly allocated MutableArray. with the specified subrange of
--- the provided MutableArray. The provided MutableArray should contain the
+-- | Return a newly allocated 'MutableArray'. with the specified subrange of
+-- the provided 'MutableArray'. The provided 'MutableArray' should contain the
 -- full subrange specified by the two Ints, but this is not checked.
 --
--- /Note:/ The provided Array should contain the full subrange
+-- /Note:/ The provided array should contain the full subrange
 -- specified by the two Ints, but this is not checked.
 cloneMutableArray :: PrimMonad m
         => MutableArray (PrimState m) a -- ^ source array
@@ -397,7 +395,7 @@ arrayLiftEq p a1 a2 = sizeofArray a1 == sizeofArray a2 && loop (sizeofArray a1 -
   where loop i | i < 0     = True
                | (# x1 #) <- indexArray## a1 i
                , (# x2 #) <- indexArray## a2 i
-               , otherwise = p x1 x2 && loop (i-1)
+               , otherwise = p x1 x2 && loop (i - 1)
 
 instance Eq a => Eq (Array a) where
   a1 == a2 = arrayLiftEq (==) a1 a2
@@ -423,7 +421,7 @@ arrayLiftCompare elemCompare a1 a2 = loop 0
     | i < mn
     , (# x1 #) <- indexArray## a1 i
     , (# x2 #) <- indexArray## a2 i
-    = elemCompare x1 x2 `mappend` loop (i+1)
+    = elemCompare x1 x2 `mappend` loop (i + 1)
     | otherwise = compare (sizeofArray a1) (sizeofArray a2)
 
 -- | Lexicographic ordering. Subject to change between major versions.
@@ -450,7 +448,7 @@ instance Foldable Array where
       go i
         | i == sz = z
         | (# x #) <- indexArray## ary i
-        = f x (go (i+1))
+        = f x (go (i + 1))
     in go 0
   {-# INLINE foldr #-}
   foldl f = \z !ary ->
@@ -458,7 +456,7 @@ instance Foldable Array where
       go i
         | i < 0 = z
         | (# x #) <- indexArray## ary i
-        = f (go (i-1)) x
+        = f (go (i - 1)) x
     in go (sizeofArray ary - 1)
   {-# INLINE foldl #-}
   foldr1 f = \ !ary ->
@@ -467,7 +465,7 @@ instance Foldable Array where
       go i =
         case indexArray## ary i of
           (# x #) | i == sz -> x
-                  | otherwise -> f x (go (i+1))
+                  | otherwise -> f x (go (i + 1))
     in if sz < 0
        then die "foldr1" "empty array"
        else go 0
@@ -489,7 +487,7 @@ instance Foldable Array where
       go i !acc
         | i == -1 = acc
         | (# x #) <- indexArray## ary i
-        = go (i-1) (f x acc)
+        = go (i - 1) (f x acc)
     in go (sizeofArray ary - 1) z
   {-# INLINE foldr' #-}
   foldl' f = \z !ary ->
@@ -498,7 +496,7 @@ instance Foldable Array where
       go i !acc
         | i == sz = acc
         | (# x #) <- indexArray## ary i
-        = go (i+1) (f acc x)
+        = go (i + 1) (f acc x)
     in go 0 z
   {-# INLINE foldl' #-}
 #endif
@@ -515,7 +513,7 @@ instance Foldable Array where
      go i !e
        | i == sz = e
        | (# x #) <- indexArray## ary i
-       = go (i+1) (max e x)
+       = go (i + 1) (max e x)
   {-# INLINE maximum #-}
   minimum ary | sz == 0   = die "minimum" "empty array"
               | (# frst #) <- indexArray## ary 0
@@ -524,7 +522,7 @@ instance Foldable Array where
          go i !e
            | i == sz = e
            | (# x #) <- indexArray## ary i
-           = go (i+1) (min e x)
+           = go (i + 1) (min e x)
   {-# INLINE minimum #-}
   sum = foldl' (+) 0
   {-# INLINE sum #-}
@@ -532,7 +530,7 @@ instance Foldable Array where
   {-# INLINE product #-}
 #endif
 
-newtype STA a = STA {_runSTA :: forall s. MutableArray# s a -> ST s (Array a)}
+newtype STA a = STA { _runSTA :: forall s. MutableArray# s a -> ST s (Array a) }
 
 runSTA :: Int -> STA a -> Array a
 runSTA !sz = \ (STA m) -> runST $ newArray_ sz >>= \ ar -> m (marray# ar)
@@ -564,8 +562,8 @@ traverseArray f = \ !ary ->
                   writeArray (MutableArray mary) i b >> m mary)
                (f x) (go (i + 1))
   in if len == 0
-     then pure emptyArray
-     else runSTA len <$> go 0
+    then pure emptyArray
+    else runSTA len <$> go 0
 {-# INLINE [1] traverseArray #-}
 
 {-# RULES
@@ -585,7 +583,7 @@ traverseArray f = \ !ary ->
 -- | This is the fastest, most straightforward way to traverse
 -- an array, but it only works correctly with a sufficiently
 -- "affine" 'PrimMonad' instance. In particular, it must only produce
--- *one* result array. 'Control.Monad.Trans.List.ListT'-transformed
+-- __one__ result array. 'Control.Monad.Trans.List.ListT'-transformed
 -- monads, for example, will not work right at all.
 traverseArrayP
   :: PrimMonad m
@@ -620,12 +618,12 @@ mapArray' f a =
                   -- We use indexArrayM here so that we will perform the
                   -- indexing eagerly even if f is lazy.
                   let !y = f x
-                  writeArray mb i y >> go (i+1)
+                  writeArray mb i y >> go (i + 1)
      in go 0
 {-# INLINE mapArray' #-}
 
 -- | Create an array from a list of a known length. If the length
---   of the list does not match the given length, this throws an exception.
+-- of the list does not match the given length, this throws an exception.
 arrayFromListN :: Int -> [a] -> Array a
 arrayFromListN n l =
   createArray n (die "fromListN" "uninitialized element") $ \sma ->
@@ -664,7 +662,7 @@ instance Functor Array where
                = return ()
                | otherwise
                = do x <- indexArrayM a i
-                    writeArray mb i (f x) >> go (i+1)
+                    writeArray mb i (f x) >> go (i + 1)
        in go 0
 #if MIN_VERSION_base(4,8,0)
   e <$ a = createArray (sizeofArray a) e (\ !_ -> pure ())
@@ -707,7 +705,7 @@ instance Alternative Array where
   empty = emptyArray
   a1 <|> a2 = createArray (sza1 + sza2) (die "<|>" "impossible") $ \ma ->
     copyArray ma 0 a1 0 sza1 >> copyArray ma sza1 a2 0 sza2
-   where sza1 = sizeofArray a1 ; sza2 = sizeofArray a2
+   where sza1 = sizeofArray a1; sza2 = sizeofArray a2
   some a | sizeofArray a == 0 = emptyArray
          | otherwise = die "some" "infinite arrays are not well defined"
   many a | sizeofArray a == 0 = pure []
@@ -722,26 +720,26 @@ instance Monad Array where
   return = pure
   (>>) = (*>)
 
-  ary >>= f = collect 0 EmptyStack (la-1)
+  ary >>= f = collect 0 EmptyStack (la - 1)
    where
-   la = sizeofArray ary
-   collect sz stk i
-     | i < 0 = createArray sz (die ">>=" "impossible") $ fill 0 stk
-     | (# x #) <- indexArray## ary i
-     , let sb = f x
-           lsb = sizeofArray sb
-       -- If we don't perform this check, we could end up allocating
-       -- a stack full of empty arrays if someone is filtering most
-       -- things out. So we refrain from pushing empty arrays.
-     = if lsb == 0
-       then collect sz stk (i - 1)
-       else collect (sz + lsb) (PushArray sb stk) (i-1)
+    la = sizeofArray ary
+    collect sz stk i
+      | i < 0 = createArray sz (die ">>=" "impossible") $ fill 0 stk
+      | (# x #) <- indexArray## ary i
+      , let sb = f x
+            lsb = sizeofArray sb
+        -- If we don't perform this check, we could end up allocating
+        -- a stack full of empty arrays if someone is filtering most
+        -- things out. So we refrain from pushing empty arrays.
+      = if lsb == 0
+        then collect sz stk (i - 1)
+        else collect (sz + lsb) (PushArray sb stk) (i - 1)
 
-   fill _   EmptyStack         _   = return ()
-   fill off (PushArray sb sbs) smb
-     | let lsb = sizeofArray sb
-     = copyArray smb off sb 0 (lsb)
-         *> fill (off + lsb) sbs smb
+    fill _ EmptyStack _ = return ()
+    fill off (PushArray sb sbs) smb
+      | let lsb = sizeofArray sb
+      = copyArray smb off sb 0 lsb
+          *> fill (off + lsb) sbs smb
 
 #if !(MIN_VERSION_base(4,13,0))
   fail = Fail.fail
@@ -761,13 +759,12 @@ zipW s f aa ab = createArray mn (die s "impossible") $ \mc ->
                x <- indexArrayM aa i
                y <- indexArrayM ab i
                writeArray mc i (f x y)
-               go (i+1)
+               go (i + 1)
            | otherwise = return ()
    in go 0
  where mn = sizeofArray aa `min` sizeofArray ab
 {-# INLINE zipW #-}
 
-#if MIN_VERSION_base(4,4,0)
 instance MonadZip Array where
   mzip aa ab = zipW "mzip" (,) aa ab
   mzipWith f aa ab = zipW "mzipWith" f aa ab
@@ -779,11 +776,10 @@ instance MonadZip Array where
           (a, b) <- indexArrayM aab i
           writeArray ma i a
           writeArray mb i b
-          go (i+1)
+          go (i + 1)
         go _ = return ()
     go 0
     (,) <$> unsafeFreezeArray ma <*> unsafeFreezeArray mb
-#endif
 
 instance MonadFix Array where
   mfix f = createArray (sizeofArray (f err))

--- a/Data/Primitive/Internal/Compat.hs
+++ b/Data/Primitive/Internal/Compat.hs
@@ -8,18 +8,15 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Compatibility functions
---
+-- Compatibility functions.
 
 module Data.Primitive.Internal.Compat (
-    isTrue#
-  ) where
+  isTrue#
+) where
 
 #if MIN_VERSION_base(4,7,0)
 import GHC.Exts (isTrue#)
-#endif
-
-#if !MIN_VERSION_base(4,7,0)
+#else
 isTrue# :: Bool -> Bool
 isTrue# b = b
 #endif

--- a/Data/Primitive/Internal/Operations.hs
+++ b/Data/Primitive/Internal/Operations.hs
@@ -8,9 +8,7 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Internal operations
---
-
+-- Internal operations.
 
 module Data.Primitive.Internal.Operations (
   setWord8Array#, setWord16Array#, setWord32Array#,
@@ -138,4 +136,3 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Double"
   setDoubleOffAddr# :: Addr# -> CPtrdiff -> CSize -> Double# -> IO ()
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Char"
   setWideCharOffAddr# :: Addr# -> CPtrdiff -> CSize -> Char# -> IO ()
-

--- a/Data/Primitive/MachDeps.hs
+++ b/Data/Primitive/MachDeps.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, MagicHash #-}
+
 -- |
 -- Module      : Data.Primitive.MachDeps
 -- Copyright   : (c) Roman Leshchinskiy 2009-2012
@@ -7,8 +8,7 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Machine-dependent constants
---
+-- Machine-dependent constants.
 
 module Data.Primitive.MachDeps where
 
@@ -120,4 +120,3 @@ type Int64_# = Int64#
 type Word64_# = Word#
 type Int64_# = Int#
 #endif
-

--- a/Data/Primitive/MutVar.hs
+++ b/Data/Primitive/MutVar.hs
@@ -8,8 +8,9 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Primitive boxed mutable variables
---
+-- Primitive boxed mutable variables. This is a generalization of
+-- "Data.IORef", "Data.STRef" and "Data.STRef.Lazy" to work in
+-- any 'PrimMonad'.
 
 module Data.Primitive.MutVar (
   MutVar(..),
@@ -25,8 +26,8 @@ module Data.Primitive.MutVar (
 ) where
 
 import Control.Monad.Primitive ( PrimMonad(..), primitive_ )
-import GHC.Exts ( MutVar#, sameMutVar#, newMutVar#,
-                  readMutVar#, writeMutVar#, atomicModifyMutVar# )
+import GHC.Exts ( MutVar#, sameMutVar#, newMutVar#
+                , readMutVar#, writeMutVar#, atomicModifyMutVar# )
 import Data.Primitive.Internal.Compat ( isTrue# )
 import Data.Typeable ( Typeable )
 
@@ -38,25 +39,38 @@ data MutVar s a = MutVar (MutVar# s a)
 instance Eq (MutVar s a) where
   MutVar mva# == MutVar mvb# = isTrue# (sameMutVar# mva# mvb#)
 
--- | Create a new 'MutVar' with the specified initial value
+-- | Create a new 'MutVar' with the specified initial value.
 newMutVar :: PrimMonad m => a -> m (MutVar (PrimState m) a)
 {-# INLINE newMutVar #-}
 newMutVar initialValue = primitive $ \s# ->
   case newMutVar# initialValue s# of
     (# s'#, mv# #) -> (# s'#, MutVar mv# #)
 
--- | Read the value of a 'MutVar'
+-- | Read the value of a 'MutVar'.
 readMutVar :: PrimMonad m => MutVar (PrimState m) a -> m a
 {-# INLINE readMutVar #-}
 readMutVar (MutVar mv#) = primitive (readMutVar# mv#)
 
--- | Write a new value into a 'MutVar'
+-- | Write a new value into a 'MutVar'.
 writeMutVar :: PrimMonad m => MutVar (PrimState m) a -> a -> m ()
 {-# INLINE writeMutVar #-}
 writeMutVar (MutVar mv#) newValue = primitive_ (writeMutVar# mv# newValue)
 
--- | Atomically mutate the contents of a 'MutVar'
-atomicModifyMutVar :: PrimMonad m => MutVar (PrimState m) a -> (a -> (a,b)) -> m b
+-- | Atomically mutate the contents of a 'MutVar'.
+--
+-- This function is useful for using 'MutVar' in a safe way in a multithreaded program.
+-- If you only have one 'MutVar', then using 'atomicModifyMutVar' to access and modify
+-- it will prevent race conditions.
+--
+-- Extending the atomicity to multiple 'MutVar's is problematic,
+-- so if you need to do anything more complicated,
+-- using 'Data.Primitive.MVar.MVar' instead is a good idea.
+--
+-- 'atomicModifyMutVar' does not apply the function strictly. This means if a program
+-- calls 'atomicModifyMutVar' many times, but seldom uses the value, thunks will pile up
+-- in memory resulting in a space leak.
+-- To avoid this problem, use 'atomicModifyMutVar'' instead.
+atomicModifyMutVar :: PrimMonad m => MutVar (PrimState m) a -> (a -> (a, b)) -> m b
 {-# INLINE atomicModifyMutVar #-}
 atomicModifyMutVar (MutVar mv#) f = primitive $ atomicModifyMutVar# mv# f
 
@@ -69,16 +83,21 @@ atomicModifyMutVar' mv f = do
   b `seq` return b
   where
     force x = case f x of
-                v@(x',_) -> x' `seq` v
+                v@(x', _) -> x' `seq` v
 
--- | Mutate the contents of a 'MutVar'
+-- | Mutate the contents of a 'MutVar'.
+--
+-- 'modifyMutVar' does not apply the function strictly. This means if a program
+-- calls 'modifyMutVar' many times, but seldom uses the value, thunks will pile up
+-- in memory resulting in a space leak.
+-- To avoid this problem, use 'modifyMutVar'' instead.
 modifyMutVar :: PrimMonad m => MutVar (PrimState m) a -> (a -> a) -> m ()
 {-# INLINE modifyMutVar #-}
 modifyMutVar (MutVar mv#) g = primitive_ $ \s# ->
   case readMutVar# mv# s# of
     (# s'#, a #) -> writeMutVar# mv# (g a) s'#
 
--- | Strict version of 'modifyMutVar'
+-- | Strict version of 'modifyMutVar'.
 modifyMutVar' :: PrimMonad m => MutVar (PrimState m) a -> (a -> a) -> m ()
 {-# INLINE modifyMutVar' #-}
 modifyMutVar' (MutVar mv#) g = primitive_ $ \s# ->

--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -11,7 +11,7 @@
 -- Maintainer  : Roman Leshchinskiy <rl@cse.unsw.edu.au>
 -- Portability : non-portable
 --
--- Primitive operations on machine addresses
+-- Primitive operations on machine addresses.
 --
 -- @since 0.6.4.0
 
@@ -41,9 +41,7 @@ import Data.Primitive.PrimArray (MutablePrimArray(..))
 import Data.Primitive.ByteArray (MutableByteArray(..))
 #endif
 
-import GHC.Base ( Int(..) )
 import GHC.Exts
-
 import GHC.Ptr
 import Foreign.Marshal.Utils
 
@@ -54,8 +52,8 @@ advancePtr :: forall a. Prim a => Ptr a -> Int -> Ptr a
 advancePtr (Ptr a#) (I# i#) = Ptr (plusAddr# a# (i# *# sizeOf# (undefined :: a)))
 
 -- | Subtract a pointer from another pointer. The result represents
---   the number of elements of type @a@ that fit in the contiguous
---   memory range bounded by these two pointers.
+-- the number of elements of type @a@ that fit in the contiguous
+-- memory range bounded by these two pointers.
 subtractPtr :: forall a. Prim a => Ptr a -> Ptr a -> Int
 {-# INLINE subtractPtr #-}
 subtractPtr (Ptr a#) (Ptr b#) = I# (quotInt# (minusAddr# a# b#) (sizeOf# (undefined :: a)))
@@ -93,8 +91,8 @@ copyPtr (Ptr dst#) (Ptr src#) n
 -- | Copy the given number of elements from the second 'Ptr' to the first. The
 -- areas may overlap.
 movePtr :: forall m a. (PrimMonad m, Prim a)
-  => Ptr a -- ^ destination address
-  -> Ptr a -- ^ source address
+  => Ptr a -- ^ destination pointer
+  -> Ptr a -- ^ source pointer
   -> Int -- ^ number of elements
   -> m ()
 {-# INLINE movePtr #-}

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -463,7 +463,7 @@ sizeofSmallMutableArray (SmallMutableArray ma) = sizeofMutableArray ma
 -- | This is the fastest, most straightforward way to traverse
 -- an array, but it only works correctly with a sufficiently
 -- "affine" 'PrimMonad' instance. In particular, it must only produce
--- __one__ result array. 'Control.Monad.Trans.List.ListT'-transformed
+-- /one/ result array. 'Control.Monad.Trans.List.ListT'-transformed
 -- monads, for example, will not work right at all.
 traverseSmallArrayP
   :: PrimMonad m

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -18,12 +18,12 @@
 --
 -- Basic types and classes for primitive array operations.
 
-module Data.Primitive.Types (
-  Prim(..),
-  sizeOf, alignment, defaultSetByteArray#, defaultSetOffAddr#,
-  PrimStorable(..),
-  Ptr(..)
-) where
+module Data.Primitive.Types
+  ( Prim(..)
+  , sizeOf, alignment, defaultSetByteArray#, defaultSetOffAddr#
+  , PrimStorable(..)
+  , Ptr(..)
+  ) where
 
 import Control.Monad.Primitive
 import Data.Primitive.MachDeps

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,0 @@
-import Distribution.Simple
-main = defaultMain
-

--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -7,20 +7,19 @@
 #include <stdlib.h>
 #include <stddef.h>
 
-void hsprimitive_memcpy( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
-void hsprimitive_memmove( void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len );
-int  hsprimitive_memcmp( HsWord8 *s1, HsWord8 *s2, size_t n );
-int  hsprimitive_memcmp_offset( HsWord8 *s1, HsInt off1, HsWord8 *s2, HsInt off2, size_t n );
+void hsprimitive_memcpy(void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len);
+void hsprimitive_memmove(void *dst, ptrdiff_t doff, void *src, ptrdiff_t soff, size_t len);
+int  hsprimitive_memcmp(HsWord8 *s1, HsWord8 *s2, size_t n);
+int  hsprimitive_memcmp_offset(HsWord8 *s1, HsInt off1, HsWord8 *s2, HsInt off2, size_t n);
 
-void hsprimitive_memset_Word8 (HsWord8 *, ptrdiff_t, size_t, HsWord8);
-void hsprimitive_memset_Word16 (HsWord16 *, ptrdiff_t, size_t, HsWord16);
-void hsprimitive_memset_Word32 (HsWord32 *, ptrdiff_t, size_t, HsWord32);
-void hsprimitive_memset_Word64 (HsWord64 *, ptrdiff_t, size_t, HsWord64);
-void hsprimitive_memset_Word (HsWord *, ptrdiff_t, size_t, HsWord);
-void hsprimitive_memset_Ptr (HsPtr *, ptrdiff_t, size_t, HsPtr);
-void hsprimitive_memset_Float (HsFloat *, ptrdiff_t, size_t, HsFloat);
-void hsprimitive_memset_Double (HsDouble *, ptrdiff_t, size_t, HsDouble);
-void hsprimitive_memset_Char (HsChar *, ptrdiff_t, size_t, HsChar);
+void hsprimitive_memset_Word8(HsWord8 *, ptrdiff_t, size_t, HsWord8);
+void hsprimitive_memset_Word16(HsWord16 *, ptrdiff_t, size_t, HsWord16);
+void hsprimitive_memset_Word32(HsWord32 *, ptrdiff_t, size_t, HsWord32);
+void hsprimitive_memset_Word64(HsWord64 *, ptrdiff_t, size_t, HsWord64);
+void hsprimitive_memset_Word(HsWord *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Ptr(HsPtr *, ptrdiff_t, size_t, HsPtr);
+void hsprimitive_memset_Float(HsFloat *, ptrdiff_t, size_t, HsFloat);
+void hsprimitive_memset_Double(HsDouble *, ptrdiff_t, size_t, HsDouble);
+void hsprimitive_memset_Char(HsChar *, ptrdiff_t, size_t, HsChar);
 
 #endif
-

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -1,4 +1,4 @@
-Cabal-Version: 2.2
+Cabal-Version:  2.2
 Name:           primitive
 Version:        0.7.2.0
 License:        BSD-3-Clause
@@ -81,17 +81,17 @@ test-suite test-qc
                , base-orphans
                , ghc-prim
                , primitive
-               , quickcheck-classes-base >=0.6 && <0.7
+               , quickcheck-classes-base >= 0.6 && <0.7
                , QuickCheck >= 2.13 && < 2.15
                , tasty ^>= 1.2 || ^>= 1.3 || ^>= 1.4
                , tasty-quickcheck
                , tagged
-               , transformers >=0.4
+               , transformers >= 0.4
                , transformers-compat
   if !impl(ghc >= 8.0)
     build-depends: semigroups
 
-  cpp-options:   -DHAVE_UNARY_LAWS
+  cpp-options: -DHAVE_UNARY_LAWS
   ghc-options: -O2
 
 benchmark bench


### PR DESCRIPTION
Changes:
* fix doc comments (add missing periods, fix grammar issues)
* add missing doc comments for `sizeofArray`, `sizeofMutableArray`, `sizeofSmallArray`, `sizeofSmallMutableArray` and `MVar`
* extend doc comments for underdocumented functions
* remove `Setup.hs` (it's not used afaict)
* remove unnecessary imports
* format (I tried to keep the original style, I mostly did stuff like adding spaces around operators and after commas)