### PR TITLE
Prepare for 0.7.3.0 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ## Changes in version 0.7.3.0
 
+  * Correct implementations of `*>` for `Array` and `SmallArray`.
+
   * Drop support for GHC < 7.10
 
   * Export `runByteArray` and `runPrimArray`.

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:  2.2
 Name:           primitive
-Version:        0.7.2.0
+Version:        0.7.3.0
 License:        BSD-3-Clause
 License-File:   LICENSE
 


### PR DESCRIPTION
Bump version to 0.7.3.0 and add missing changelog entry for correcting implementations of `*>` operator.

@Bodigrim Are you aware of anything else that needs to land in this release?