### PR TITLE
Relax minimum cabal version

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -1,4 +1,4 @@
-Cabal-Version:  2.2
+Cabal-Version:  2.0
 Name:           primitive
 Version:        0.7.3.0
 License:        BSD-3-Clause


### PR DESCRIPTION
I just tried to build it against lts-11.22 (which has `Cabal-2.0.1.0`) and it did build just fine, so I don't see a reason to set it higher than necessary.