### PR TITLE
Drop support for GHC 7.10

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -82,10 +82,8 @@ import Data.Data ( Data(..), mkNoRepType )
 import qualified Language.Haskell.TH.Syntax as TH
 import qualified Language.Haskell.TH.Lib as TH
 
-#if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as SG
 import qualified Data.Foldable as F
-#endif
 
 import System.IO.Unsafe (unsafePerformIO, unsafeDupablePerformIO)
 
@@ -749,7 +747,6 @@ replicateByteArray n arr = runST $ do
   go 0
   unsafeFreezeByteArray marr
 
-#if MIN_VERSION_base(4,9,0)
 instance SG.Semigroup ByteArray where
   (<>) = appendByteArray
   sconcat = mconcat . F.toList
@@ -757,7 +754,6 @@ instance SG.Semigroup ByteArray where
     LT -> die "stimes" "negative multiplier"
     EQ -> emptyByteArray
     GT -> replicateByteArray (fromIntegral n) arr
-#endif
 
 instance Monoid ByteArray where
   mempty = emptyByteArray

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -120,10 +120,8 @@ import qualified Data.Primitive.Types as PT
 import qualified GHC.ST as GHCST
 import Language.Haskell.TH.Syntax (Lift (..))
 
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (Semigroup)
 import qualified Data.Semigroup as SG
-#endif
 
 #if __GLASGOW_HASKELL__ >= 802
 import qualified GHC.Exts as Exts
@@ -253,13 +251,11 @@ primArrayToByteArray (PrimArray x) = PB.ByteArray x
 byteArrayToPrimArray :: ByteArray -> PrimArray a
 byteArrayToPrimArray (PB.ByteArray x) = PrimArray x
 
-#if MIN_VERSION_base(4,9,0)
 -- | @since 0.6.4.0
 instance Semigroup (PrimArray a) where
   x <> y = byteArrayToPrimArray (primArrayToByteArray x SG.<> primArrayToByteArray y)
   sconcat = byteArrayToPrimArray . SG.sconcat . fmap primArrayToByteArray
   stimes i arr = byteArrayToPrimArray (SG.stimes i (primArrayToByteArray arr))
-#endif
 
 -- | @since 0.6.4.0
 instance Monoid (PrimArray a) where

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE CPP, UnboxedTuples, MagicHash, DeriveDataTypeable #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, StandaloneDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE DeriveGeneric #-}
-#endif
 
 #include "HsBaseConfig.h"
 
@@ -52,9 +50,7 @@ import Control.Applicative (Const(..))
 import Data.Functor.Identity (Identity(..))
 import qualified Data.Monoid as Monoid
 import Data.Ord (Down(..))
-#if MIN_VERSION_base(4,9,0)
 import qualified Data.Semigroup as Semigroup
-#endif
 
 -- | Class of types supporting primitive array operations. This includes
 -- interfacing with GC-managed memory (functions suffixed with @ByteArray#@)
@@ -444,7 +440,6 @@ deriving instance Prim a => Prim (Monoid.Dual a)
 deriving instance Prim a => Prim (Monoid.Sum a)
 -- | @since 0.6.5.0
 deriving instance Prim a => Prim (Monoid.Product a)
-#if MIN_VERSION_base(4,9,0)
 -- | @since 0.6.5.0
 deriving instance Prim a => Prim (Semigroup.First a)
 -- | @since 0.6.5.0
@@ -453,4 +448,3 @@ deriving instance Prim a => Prim (Semigroup.Last a)
 deriving instance Prim a => Prim (Semigroup.Min a)
 -- | @since 0.6.5.0
 deriving instance Prim a => Prim (Semigroup.Max a)
-#endif

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -19,7 +19,6 @@ Extra-Source-Files: changelog.md
                     test/LICENSE
 
 Tested-With:
-  GHC == 7.10.3,
   GHC == 8.0.2,
   GHC == 8.2.2,
   GHC == 8.4.4,
@@ -49,12 +48,10 @@ Library
   Other-Modules:
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.8 && < 4.17
+  Build-Depends: base >= 4.9 && < 4.17
                , deepseq >= 1.1 && < 1.5
-               , transformers >= 0.4.2 && < 0.7
-               , template-haskell >= 2.5
-  if !impl(ghc >= 8.0)
-    Build-Depends: fail == 4.9.*
+               , transformers >= 0.5 && < 0.7
+               , template-haskell >= 2.11
 
   Ghc-Options: -O2
 
@@ -83,10 +80,8 @@ test-suite test-qc
                , tasty ^>= 1.2 || ^>= 1.3 || ^>= 1.4
                , tasty-quickcheck
                , tagged
-               , transformers >= 0.4
+               , transformers >= 0.5
                , transformers-compat
-  if !impl(ghc >= 8.0)
-    build-depends: semigroups
 
   cpp-options: -DHAVE_UNARY_LAWS
   ghc-options: -O2
@@ -108,7 +103,7 @@ benchmark bench
     , primitive
     , deepseq
     , tasty-bench
-    , transformers >= 0.3
+    , transformers >= 0.5
 
 source-repository head
   type:     git

--- a/test/main.hs
+++ b/test/main.hs
@@ -31,10 +31,8 @@ import PrimLaws (primLaws)
 import Data.Functor.Identity (Identity(..))
 import qualified Data.Monoid as Monoid
 import Data.Ord (Down(..))
-#if MIN_VERSION_base(4,9,0)
 import Data.Semigroup (stimes, stimesMonoid)
 import qualified Data.Semigroup as Semigroup
-#endif
 #if !(MIN_VERSION_base(4,11,0))
 import Data.Monoid ((<>))
 #endif
@@ -70,10 +68,8 @@ main = do
       , TQC.testProperty "mapArray'" (QCCL.mapProp int16 int32 mapArray')
       , TQC.testProperty "*>" $ \(xs :: Array Int) (ys :: Array Int) -> toList (xs *> ys) === (toList xs *> toList ys)
       , TQC.testProperty "<*" $ \(xs :: Array Int) (ys :: Array Int) -> toList (xs <* ys) === (toList xs <* toList ys)
-#if MIN_VERSION_base(4,9,0)
       , lawsToTest (QCC.semigroupLaws (Proxy :: Proxy (Array Int)))
       , TQC.testProperty "stimes" $ \(QC.NonNegative (n :: Int)) (xs :: Array Int) -> stimes n xs == stimesMonoid n xs
-#endif
       ]
     , testGroup "SmallArray"
       [ lawsToTest (QCC.eqLaws (Proxy :: Proxy (SmallArray Int)))
@@ -89,10 +85,8 @@ main = do
       , TQC.testProperty "mapSmallArray'" (QCCL.mapProp int16 int32 mapSmallArray')
       , TQC.testProperty "*>" $ \(xs :: SmallArray Int) (ys :: SmallArray Int) -> toList (xs *> ys) === (toList xs *> toList ys)
       , TQC.testProperty "<*" $ \(xs :: SmallArray Int) (ys :: SmallArray Int) -> toList (xs <* ys) === (toList xs <* toList ys)
-#if MIN_VERSION_base(4,9,0)
       , lawsToTest (QCC.semigroupLaws (Proxy :: Proxy (SmallArray Int)))
       , TQC.testProperty "stimes" $ \(QC.NonNegative (n :: Int)) (xs :: SmallArray Int) -> stimes n xs == stimesMonoid n xs
-#endif
       ]
     , testGroup "ByteArray"
       [ testGroup "Ordering"
@@ -121,10 +115,8 @@ main = do
       , lawsToTest (QCC.showReadLaws (Proxy :: Proxy (Array Int)))
       , lawsToTest (QCC.isListLaws (Proxy :: Proxy ByteArray))
       , TQC.testProperty "foldrByteArray" (QCCL.foldrProp word8 foldrByteArray)
-#if MIN_VERSION_base(4,9,0)
       , lawsToTest (QCC.semigroupLaws (Proxy :: Proxy ByteArray))
       , TQC.testProperty "stimes" $ \(QC.NonNegative (n :: Int)) (xs :: ByteArray) -> stimes n xs == stimesMonoid n xs
-#endif
       ]
     , testGroup "PrimArray"
       [ lawsToTest (QCC.eqLaws (Proxy :: Proxy (PrimArray Word16)))
@@ -154,10 +146,8 @@ main = do
       , TQC.testProperty "mapMaybePrimArray" (QCCL.mapMaybeProp int16 int32 mapMaybePrimArray)
       , TQC.testProperty "mapMaybePrimArrayA" (QCCL.mapMaybeMProp int16 int32 mapMaybePrimArrayA)
       , TQC.testProperty "mapMaybePrimArrayP" (QCCL.mapMaybeMProp int16 int32 mapMaybePrimArrayP)
-#if MIN_VERSION_base(4,9,0)
       , lawsToTest (QCC.semigroupLaws (Proxy :: Proxy (PrimArray Word16)))
       , TQC.testProperty "stimes" $ \(QC.NonNegative (n :: Int)) (xs :: PrimArray Word16) -> stimes n xs == stimesMonoid n xs
-#endif
       ]
     , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
@@ -184,24 +174,20 @@ main = do
       , renameLawsToTest "Dual" (primLaws (Proxy :: Proxy (Monoid.Dual Int16)))
       , renameLawsToTest "Sum" (primLaws (Proxy :: Proxy (Monoid.Sum Int16)))
       , renameLawsToTest "Product" (primLaws (Proxy :: Proxy (Monoid.Product Int16)))
-#if MIN_VERSION_base(4,9,0)
       , renameLawsToTest "First" (primLaws (Proxy :: Proxy (Semigroup.First Int16)))
       , renameLawsToTest "Last" (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
-#endif
       ]
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)
 -- Const, Dual, Sum, Product: all have Arbitrary instances defined
 -- in QuickCheck itself
-#if MIN_VERSION_base(4,9,0)
 deriving instance Arbitrary a => Arbitrary (Semigroup.First a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
-#endif
 
 word8 :: Proxy Word8
 word8 = Proxy
@@ -371,10 +357,8 @@ testByteArray = do
         fail $ "ByteArray Monoid mappend not associative"
     unless (mconcat [arr1,arr2,arr3,arr4,arr5] == (arr1 <> arr2 <> arr3 <> arr4 <> arr5)) $
         fail $ "ByteArray Monoid mconcat incorrect"
-#if MIN_VERSION_base(4,9,0)
     unless (stimes (3 :: Int) arr4 == (arr4 <> arr4 <> arr4)) $
         fail $ "ByteArray Semigroup stimes incorrect"
-#endif
 
 mkByteArray :: Prim a => [a] -> ByteArray
 mkByteArray xs = runST $ do


### PR DESCRIPTION
Resolves #337.

This also gets rid of a bunch of CPP. I bumped the version bounds to be appropriate for base >= 4.9.