### PR TITLE
GHC 9.4 support

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -48,7 +48,7 @@ Library
   Other-Modules:
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.9 && < 4.17
+  Build-Depends: base >= 4.9 && < 4.18
                , deepseq >= 1.1 && < 1.5
                , transformers >= 0.5 && < 0.7
                , template-haskell >= 2.11


### PR DESCRIPTION
The current release on Hackage fails to build with 9.4, but the version on `master` works fine with `--allow-newer` (with a few warnings about some new syntax).

Omitting `--allow-newer` gives us an error with QuickCheck and `splitmix`, but those are also fine for now.