### PR TITLE
Fix some warnings, test under GHC 9.6.1 alpha2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,25 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4.1']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6.0.20230128']
         include:
         - os: windows-latest
           ghc: 'latest'
         - os: macOS-latest
           ghc: 'latest'
-        - os: ubuntu-latest
-          ghc: 'latest'
+        ## Already covered by '9.4'
+        # - os: ubuntu-latest
+        #   ghc: 'latest'
     steps:
     - uses: actions/checkout@v3
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
+        ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
     - name: Update cabal package database
       run: cabal update
     - uses: actions/cache@v2

--- a/Control/Monad/Primitive.hs
+++ b/Control/Monad/Primitive.hs
@@ -33,7 +33,9 @@ import GHC.Exts   ( State#, RealWorld, noDuplicate#, touch#
 import GHC.IO     ( IO(..) )
 import GHC.ST     ( ST(..) )
 
+#if __GLASGOW_HASKELL__ >= 802
 import qualified Control.Monad.ST.Lazy as L
+#endif
 
 import Control.Monad.Trans.Class (lift)
 

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -762,7 +762,7 @@ instance Semigroup (Array a) where
 instance Monoid (Array a) where
   mempty = empty
 #if !(MIN_VERSION_base(4,11,0))
-  mappend = (<|>)
+  mappend = (<>)
 #endif
   mconcat l = createArray sz (die "mconcat" "impossible") $ \ma ->
     let go !_  [    ] = return ()

--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -70,11 +70,15 @@ import Control.Monad.Primitive
 import Control.Monad.ST
 import Data.Primitive.Types
 
+#if MIN_VERSION_base(4,10,0)
 import qualified GHC.ST as GHCST
+#endif
 
 import Foreign.C.Types
 import Data.Word ( Word8 )
+#if __GLASGOW_HASKELL__ >= 802
 import qualified GHC.Exts as Exts
+#endif
 import GHC.Exts hiding (setByteArray#)
 
 #if __GLASGOW_HASKELL__ < 804

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -110,7 +110,9 @@ module Data.Primitive.PrimArray
 import GHC.Exts
 import Data.Primitive.Types
 import Data.Primitive.ByteArray (ByteArray(..))
+#if !MIN_VERSION_base(4,11,0)
 import Data.Monoid ((<>))
+#endif
 import Control.Applicative
 import Control.DeepSeq
 import Control.Monad.Primitive
@@ -118,10 +120,14 @@ import Control.Monad.ST
 import qualified Data.List as L
 import qualified Data.Primitive.ByteArray as PB
 import qualified Data.Primitive.Types as PT
+#if MIN_VERSION_base(4,10,0)
 import qualified GHC.ST as GHCST
+#endif
 import Language.Haskell.TH.Syntax (Lift (..))
 
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup)
+#endif
 import qualified Data.Semigroup as SG
 
 #if __GLASGOW_HASKELL__ >= 802

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -80,9 +80,6 @@ import Control.Monad.Zip
 import Data.Data
 import Data.Foldable as Foldable
 import Data.Functor.Identity
-#if !(MIN_VERSION_base(4,10,0))
-import Data.Monoid
-#endif
 import qualified GHC.ST as GHCST
 import qualified Data.Semigroup as Sem
 import Text.ParserCombinators.ReadP
@@ -798,7 +795,7 @@ instance Sem.Semigroup (SmallArray a) where
 instance Monoid (SmallArray a) where
   mempty = empty
 #if !(MIN_VERSION_base(4,11,0))
-  mappend = (<|>)
+  mappend = (Sem.<>)
 #endif
   mconcat l = createSmallArray n (die "mconcat" "impossible") $ \ma ->
     let go !_  [    ] = return ()

--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,4 @@ packages: primitive.cabal
 
 
 package primitive
-  ghc-options: -Wall
+  ghc-options: -Wall -Wcompat

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -30,6 +30,8 @@ Tested-With:
 
 Library
   Default-Language: Haskell2010
+  Default-Extensions:
+        TypeOperators
   Other-Extensions:
         BangPatterns, CPP, DeriveDataTypeable,
         MagicHash, TypeFamilies, UnboxedTuples, UnliftedFFITypes

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -19,14 +19,15 @@ Extra-Source-Files: changelog.md
                     test/LICENSE
 
 Tested-With:
-  GHC == 8.0.2,
-  GHC == 8.2.2,
-  GHC == 8.4.4,
-  GHC == 8.6.5,
-  GHC == 8.8.4,
-  GHC == 8.10.7,
-  GHC == 9.0.2,
-  GHC == 9.2.2
+  GHC == 8.0.2
+  GHC == 8.2.2
+  GHC == 8.4.4
+  GHC == 8.6.5
+  GHC == 8.8.4
+  GHC == 8.10.7
+  GHC == 9.0.2
+  GHC == 9.2.5
+  GHC == 9.4.4
 
 Library
   Default-Language: Haskell2010
@@ -53,7 +54,7 @@ Library
   Other-Modules:
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.9 && < 4.18
+  Build-Depends: base >= 4.9 && < 4.19
                , deepseq >= 1.1 && < 1.5
                , transformers >= 0.5 && < 0.7
                , template-haskell >= 2.11


### PR DESCRIPTION
Some polishing relevant for the next release:
- fix some warnings for GHC 8.0, 8.4 up, 9.4
- test under GHC 9.6.1 alpha2