### PR TITLE
Extend CI to GHC 9.6.1 alpha2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,31 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4.1']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4']
         include:
         - os: windows-latest
           ghc: 'latest'
         - os: macOS-latest
           ghc: 'latest'
         - os: ubuntu-latest
-          ghc: 'latest'
+          ghc: '9.6.0.20230128'
+          ghcup-release-channel: https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
+        ## Already covered by '9.4'
+        # - os: ubuntu-latest
+        #   ghc: 'latest'
     steps:
     - uses: actions/checkout@v3
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
+        ghcup-release-channel: ${{ matrix.ghcup-release-channel }}
     - name: Update cabal package database
       run: cabal update
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       name: Cache cabal stuff
       with:
         path: |
@@ -40,9 +45,9 @@ jobs:
           dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}
     - name: Build
-      run: cabal build
+      run: cabal build all --enable-tests
     - name: Test
-      run: cabal test
+      run: cabal test all --enable-tests
     - name: Bench
       run: cabal bench --benchmark-option=-l
     - name: Haddock

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,5 @@ packages: primitive.cabal
 
 package primitive
   ghc-options: -Wall
+
+allow-newer: tagged-0.8.6.1:template-haskell

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -19,14 +19,15 @@ Extra-Source-Files: changelog.md
                     test/LICENSE
 
 Tested-With:
-  GHC == 8.0.2,
-  GHC == 8.2.2,
-  GHC == 8.4.4,
-  GHC == 8.6.5,
-  GHC == 8.8.4,
-  GHC == 8.10.7,
-  GHC == 9.0.2,
-  GHC == 9.2.2
+  GHC == 8.0.2
+  GHC == 8.2.2
+  GHC == 8.4.4
+  GHC == 8.6.5
+  GHC == 8.8.4
+  GHC == 8.10.7
+  GHC == 9.0.2
+  GHC == 9.2.5
+  GHC == 9.4.4
 
 Library
   Default-Language: Haskell2010
@@ -51,7 +52,7 @@ Library
   Other-Modules:
         Data.Primitive.Internal.Operations
 
-  Build-Depends: base >= 4.9 && < 4.18
+  Build-Depends: base >= 4.9 && < 4.19
                , deepseq >= 1.1 && < 1.5
                , transformers >= 0.5 && < 0.7
                , template-haskell >= 2.11


### PR DESCRIPTION
- bump outdated actions
- get GHC 9.6.0 from ghcup prerelease channel
- bumps to allow GHC 9.6.0