### PR TITLE
Add `sizeOfType`, `alignmentOfType`

### DIFF
--- a/Data/Primitive/Ptr.hs
+++ b/Data/Primitive/Ptr.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- |
 -- Module      : Data.Primitive.Ptr
@@ -37,6 +38,7 @@ import Data.Primitive.Types
 import Data.Primitive.PrimArray (copyPtrToMutablePrimArray)
 import Data.Primitive.ByteArray (copyPtrToMutableByteArray)
 
+import Data.Proxy
 import GHC.Exts
 import GHC.Ptr
 import Foreign.Marshal.Utils
@@ -45,14 +47,14 @@ import Foreign.Marshal.Utils
 -- | Offset a pointer by the given number of elements.
 advancePtr :: forall a. Prim a => Ptr a -> Int -> Ptr a
 {-# INLINE advancePtr #-}
-advancePtr (Ptr a#) (I# i#) = Ptr (plusAddr# a# (i# *# sizeOf# (undefined :: a)))
+advancePtr (Ptr a#) (I# i#) = Ptr (plusAddr# a# (i# *# sizeOfType# (Proxy :: Proxy a)))
 
 -- | Subtract a pointer from another pointer. The result represents
 -- the number of elements of type @a@ that fit in the contiguous
 -- memory range bounded by these two pointers.
 subtractPtr :: forall a. Prim a => Ptr a -> Ptr a -> Int
 {-# INLINE subtractPtr #-}
-subtractPtr (Ptr a#) (Ptr b#) = I# (quotInt# (minusAddr# a# b#) (sizeOf# (undefined :: a)))
+subtractPtr (Ptr a#) (Ptr b#) = I# (quotInt# (minusAddr# a# b#) (sizeOfType# (Proxy :: Proxy a)))
 
 -- | Read a value from a memory position given by a pointer and an offset.
 -- The memory block the address refers to must be immutable. The offset is in
@@ -82,7 +84,7 @@ copyPtr :: forall m a. (PrimMonad m, Prim a)
   -> m ()
 {-# INLINE copyPtr #-}
 copyPtr (Ptr dst#) (Ptr src#) n
-  = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) (n * sizeOf (undefined :: a))
+  = unsafePrimToPrim $ copyBytes (Ptr dst#) (Ptr src#) (n * sizeOfType @a)
 
 -- | Copy the given number of elements from the second 'Ptr' to the first. The
 -- areas may overlap.
@@ -93,7 +95,7 @@ movePtr :: forall m a. (PrimMonad m, Prim a)
   -> m ()
 {-# INLINE movePtr #-}
 movePtr (Ptr dst#) (Ptr src#) n
-  = unsafePrimToPrim $ moveBytes (Ptr dst#) (Ptr src#) (n * sizeOf (undefined :: a))
+  = unsafePrimToPrim $ moveBytes (Ptr dst#) (Ptr src#) (n * sizeOfType @a)
 
 -- | Fill a memory block with the given value. The length is in
 -- elements of type @a@ rather than in bytes.

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -148,7 +148,7 @@ class Prim a where
 
 -- | A dummy value of type @a@.
 dummy :: a
-dummy = errorWithoutStackTrace "dummy"
+dummy = errorWithoutStackTrace "Data.Primitive.Types: implementation mistake in `Prim` instance"
 {-# NOINLINE dummy #-}
 
 -- | The size of values of type @a@. This has to be used with TypeApplications: @sizeOfType \@a@.

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -29,7 +29,7 @@
 
 module Data.Primitive.Types
   ( Prim(..)
-  , sizeOf, alignment, defaultSetByteArray#, defaultSetOffAddr#
+  , sizeOf, sizeOfType, alignment, alignmentOfType, defaultSetByteArray#, defaultSetOffAddr#
   , PrimStorable(..)
   , Ptr(..)
   ) where

--- a/test/src/PrimLaws.hs
+++ b/test/src/PrimLaws.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 {-# OPTIONS_GHC -Wall #-}
@@ -54,7 +55,7 @@ primLaws p = Laws "Prim"
 primListAddr :: forall a. (Prim a, Eq a, Arbitrary a, Show a) => Proxy a -> Property
 primListAddr _ = property $ \(as :: [a]) -> unsafePerformIO $ do
   let len = L.length as
-  ptr :: Ptr a <- mallocBytes (len * P.sizeOf (undefined :: a))
+  ptr :: Ptr a <- mallocBytes (len * P.sizeOfType @a)
   let go :: Int -> [a] -> IO ()
       go !ix xs = case xs of
         [] -> return ()
@@ -113,7 +114,7 @@ primPutGetAddr :: forall a. (Prim a, Eq a, Arbitrary a, Show a) => Proxy a -> Pr
 primPutGetAddr _ = property $ \(a :: a) len -> (len > 0) ==> do
   ix <- choose (0,len - 1)
   return $ unsafePerformIO $ do
-    ptr :: Ptr a <- mallocBytes (len * P.sizeOf (undefined :: a))
+    ptr :: Ptr a <- mallocBytes (len * P.sizeOfType @a)
     writeOffPtr ptr ix a
     a' <- readOffPtr ptr ix
     free ptr


### PR DESCRIPTION
Closes #344.

This adds `sizeOfType` and `alignmentOfType` "methods" to the `Prim` class. They're `Int` values, since class dictionaries apparently can't contain unboxed values, but I'm doubtful that `Int#` would bring any advantages anyway. I chose the `OfType` suffix to indicate that they're about the size/alignment *of a type* and that they need a *type* argument (via `TypeApplications`). I also added doc comments to encourage the use of these new values.

The PR is marked as draft, since I first want to get the new definitions reviewed, before changing uses of `sizeOf`/`sizeOf#` and `alignment`/`alignment#` throughout the package.

EDIT: As per @lehins suggestion, I added `sizeOfType#` and `alignmentOfType#` methods instead and made `sizeOfType` and `alignmentOfType` standalone values.