### PR TITLE
Add Prim instances for Data.Complex

### DIFF
--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -134,7 +134,7 @@ sizeOf x = I# (sizeOf# x)
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
 
--- | @since 0.6.5.0
+-- | @since 0.9.0.0
 instance Prim a => Prim (Complex a) where
   sizeOf# _ = 2# *# sizeOf# (undefined :: a)
   alignment# _ = alignment# (undefined :: a)

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -38,6 +38,7 @@ import Data.Primitive.Internal.Operations
 import Foreign.Ptr (IntPtr, intPtrToPtr, ptrToIntPtr, WordPtr, wordPtrToPtr, ptrToWordPtr)
 import Foreign.C.Types
 import System.Posix.Types
+import Data.Complex
 
 import GHC.Word (Word8(..), Word16(..), Word32(..), Word64(..))
 import GHC.Int (Int8(..), Int16(..), Int32(..), Int64(..))
@@ -53,7 +54,6 @@ import qualified Foreign.Storable as FS
 
 import GHC.IO (IO(..))
 import qualified GHC.Exts
-
 
 import Control.Applicative (Const(..))
 import Data.Functor.Identity (Identity(..))
@@ -133,6 +133,47 @@ sizeOf x = I# (sizeOf# x)
 -- to 'Data.Primitive.Types' in version 0.6.3.0.
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
+
+-- | @since 0.6.5.0
+instance Prim a => Prim (Complex a) where
+  sizeOf# _ = 2# *# sizeOf# (undefined :: a)
+  alignment# _ = alignment# (undefined :: a)
+  indexByteArray# arr# i# =
+    let x = indexByteArray# arr# (2# *# i#)
+        y = indexByteArray# arr# (2# *# i# +# 1#)
+    in x :+ y
+  readByteArray# arr# i# =
+    \s0 -> case readByteArray# arr# (2# *# i#) s0 of
+       (# s1#, x #) -> case readByteArray# arr# (2# *# i# +# 1#) s1# of
+          (# s2#, y #) -> (# s2#, x :+ y #)
+  writeByteArray# arr# i# (a :+ b) =
+    \s0 -> case writeByteArray# arr# (2# *# i#) a s0 of
+       s1 -> case writeByteArray# arr# (2# *# i# +# 1#) b s1 of
+         s2 -> s2
+  setByteArray# = defaultSetByteArray#
+  indexOffAddr# addr# i# =
+    let x = indexOffAddr# addr# (2# *# i#)
+        y = indexOffAddr# addr# (2# *# i# +# 1#)
+    in x :+ y
+  readOffAddr# addr# i# =
+    \s0 -> case readOffAddr# addr# (2# *# i#) s0 of
+       (# s1, x #) -> case readOffAddr# addr# (2# *# i# +# 1#) s1 of
+         (# s2, y #) -> (# s2, x :+ y #)
+  writeOffAddr# addr# i# (a :+ b) =
+    \s0 -> case writeOffAddr# addr# (2# *# i#) a s0 of
+       s1 -> case writeOffAddr# addr# (2# *# i# +# 1#) b s1 of
+         s2 -> s2
+  setOffAddr# = defaultSetOffAddr#
+  {-# INLINE sizeOf# #-}
+  {-# INLINE alignment# #-}
+  {-# INLINE indexByteArray# #-}
+  {-# INLINE readByteArray# #-}
+  {-# INLINE writeByteArray# #-}
+  {-# INLINE setByteArray# #-}
+  {-# INLINE indexOffAddr# #-}
+  {-# INLINE readOffAddr# #-}
+  {-# INLINE writeOffAddr# #-}
+  {-# INLINE setOffAddr# #-}
 
 -- | An implementation of 'setByteArray#' that calls 'writeByteArray#'
 -- to set each element. This is helpful when writing a 'Prim' instance

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
   * Use `mutableByteArrayContents#` in GHC 9.2+
 
+  * Add `Prim` instance for `Complex`.
+
   * Add `getSizeofSmallMutableArray` that wraps `getSizeofSmallMutableArray#`
     from `GHC.Exts`.
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -18,6 +18,7 @@
 
 import Control.Monad
 import Control.Monad.ST
+import Data.Complex
 import Data.Primitive
 import Data.Word
 import Data.Proxy (Proxy(..))
@@ -152,6 +153,9 @@ main = do
     , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
       ]
+    , testGroup "Complex"
+      [ lawsToTest (primLaws (Proxy :: Proxy (Complex Double)))
+      ]
 #if __GLASGOW_HASKELL__ >= 805
     , testGroup "PrimStorable"
       [ lawsToTest (QCC.storableLaws (Proxy :: Proxy Derived))
@@ -179,15 +183,29 @@ main = do
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
       ]
+    , testGroup "Newtypes"
+      [ lawsToTest (primLaws (Proxy :: Proxy (Const Int16 Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Down Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Identity Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Dual Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Sum Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Product Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.First Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
+      ]
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)
 -- Const, Dual, Sum, Product: all have Arbitrary instances defined
 -- in QuickCheck itself
+#if MIN_VERSION_base(4,9,0)
 deriving instance Arbitrary a => Arbitrary (Semigroup.First a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
+#endif
 
 word8 :: Proxy Word8
 word8 = Proxy

--- a/test/main.hs
+++ b/test/main.hs
@@ -153,9 +153,6 @@ main = do
     , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
       ]
-    , testGroup "Complex"
-      [ lawsToTest (primLaws (Proxy :: Proxy (Complex Double)))
-      ]
 #if __GLASGOW_HASKELL__ >= 805
     , testGroup "PrimStorable"
       [ lawsToTest (QCC.storableLaws (Proxy :: Proxy Derived))
@@ -182,30 +179,17 @@ main = do
       , renameLawsToTest "Last" (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
-      ]
-    , testGroup "Newtypes"
-      [ lawsToTest (primLaws (Proxy :: Proxy (Const Int16 Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Down Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Identity Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Dual Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Sum Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Product Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.First Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
+      , renameLawsToTest "Complex" (primLaws (Proxy :: Proxy (Complex Double)))
       ]
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)
 -- Const, Dual, Sum, Product: all have Arbitrary instances defined
 -- in QuickCheck itself
-#if MIN_VERSION_base(4,9,0)
 deriving instance Arbitrary a => Arbitrary (Semigroup.First a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
-#endif
 
 word8 :: Proxy Word8
 word8 = Proxy


### PR DESCRIPTION
Add tests for the Complex instance. Remove usage of -XInstanceSigs because of older GHCs.

This is just https://github.com/haskell/primitive/pull/183 but squashed and rebased. I'm going to wait to merge until the `sizeOfType#` branch is merged since it will change how the `Prim` instance for `Complex` is defined.