### PR TITLE
Update documentation for `size*`/`alignment*`

### DIFF
--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -74,25 +74,25 @@ import Data.Ord (Down(..))
 class Prim a where
   -- We use `Proxy` instead of `Proxy#`, since the latter doesn't work with GND for GHC <= 8.8.
 
-  -- | The size of values of type @a@. This has to be used with TypeApplications: @sizeOfType \@a@.
+  -- | The size of values of type @a@ in bytes. This has to be used with TypeApplications: @sizeOfType \@a@.
   --
   -- @since TODO
   sizeOfType# :: Proxy a -> Int#
   sizeOfType# _ = sizeOf# (dummy :: a)
 
-  -- | The size of values of type @a@. The argument is not used.
+  -- | The size of values of type @a@ in bytes. The argument is not used.
   --
   -- It is recommended to use 'sizeOfType#' instead.
   sizeOf# :: a -> Int#
   sizeOf# _ = sizeOfType# (Proxy :: Proxy a)
 
-  -- | The alignment of values of type @a@. This has to be used with TypeApplications: @alignmentOfType \@a@.
+  -- | The alignment of values of type @a@ in bytes. This has to be used with TypeApplications: @alignmentOfType \@a@.
   --
   -- @since TODO
   alignmentOfType# :: Proxy a -> Int#
   alignmentOfType# _ = alignment# (dummy :: a)
 
-  -- | The alignment of values of type @a@. The argument is not used.
+  -- | The alignment of values of type @a@ in bytes. The argument is not used.
   --
   -- It is recommended to use 'alignmentOfType#' instead.
   alignment# :: a -> Int#
@@ -151,13 +151,18 @@ dummy :: a
 dummy = errorWithoutStackTrace "Data.Primitive.Types: implementation mistake in `Prim` instance"
 {-# NOINLINE dummy #-}
 
--- | The size of values of type @a@. This has to be used with TypeApplications: @sizeOfType \@a@.
+-- | The size of values of type @a@ in bytes. This has to be used with TypeApplications: @sizeOfType \@a@.
+--
+-- >>> :set -XTypeApplications
+-- >>> import Data.Int (Int32)
+-- >>> sizeOfType @Int32
+-- 4
 --
 -- @since TODO
 sizeOfType :: forall a. Prim a => Int
 sizeOfType = I# (sizeOfType# (Proxy :: Proxy a))
 
--- | The size of values of type @a@. The argument is not used.
+-- | The size of values of type @a@ in bytes. The argument is not used.
 --
 -- It is recommended to use 'sizeOfType' instead.
 --
@@ -166,13 +171,13 @@ sizeOfType = I# (sizeOfType# (Proxy :: Proxy a))
 sizeOf :: Prim a => a -> Int
 sizeOf x = I# (sizeOf# x)
 
--- | The alignment of values of type @a@. This has to be used with TypeApplications: @alignmentOfType \@a@.
+-- | The alignment of values of type @a@ in bytes. This has to be used with TypeApplications: @alignmentOfType \@a@.
 --
 -- @since TODO
 alignmentOfType :: forall a. Prim a => Int
 alignmentOfType = I# (alignmentOfType# (Proxy :: Proxy a))
 
--- | The alignment of values of type @a@. The argument is not used.
+-- | The alignment of values of type @a@ in bytes. The argument is not used.
 --
 -- It is recommended to use 'alignmentOfType' instead.
 --

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -76,7 +76,7 @@ class Prim a where
 
   -- | The size of values of type @a@ in bytes. This has to be used with TypeApplications: @sizeOfType \@a@.
   --
-  -- @since TODO
+  -- @since 0.9.0.0
   sizeOfType# :: Proxy a -> Int#
   sizeOfType# _ = sizeOf# (dummy :: a)
 
@@ -88,7 +88,7 @@ class Prim a where
 
   -- | The alignment of values of type @a@ in bytes. This has to be used with TypeApplications: @alignmentOfType \@a@.
   --
-  -- @since TODO
+  -- @since 0.9.0.0
   alignmentOfType# :: Proxy a -> Int#
   alignmentOfType# _ = alignment# (dummy :: a)
 
@@ -158,7 +158,7 @@ dummy = errorWithoutStackTrace "Data.Primitive.Types: implementation mistake in 
 -- >>> sizeOfType @Int32
 -- 4
 --
--- @since TODO
+-- @since 0.9.0.0
 sizeOfType :: forall a. Prim a => Int
 sizeOfType = I# (sizeOfType# (Proxy :: Proxy a))
 
@@ -173,7 +173,7 @@ sizeOf x = I# (sizeOf# x)
 
 -- | The alignment of values of type @a@ in bytes. This has to be used with TypeApplications: @alignmentOfType \@a@.
 --
--- @since TODO
+-- @since 0.9.0.0
 alignmentOfType :: forall a. Prim a => Int
 alignmentOfType = I# (alignmentOfType# (Proxy :: Proxy a))
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Changes in version 0.9.0.0
-  
+
   * Fix signature of `keepAlive`.
 
   * Remove re-export of `fromList` and `fromListN` from `Data.Primitive.Array`.
@@ -8,6 +8,9 @@
 
   * Add `getSizeofSmallMutableArray` that wraps `getSizeofSmallMutableArray#`
     from `GHC.Exts`.
+
+  * Add standalone `sizeOfType`/`alignmentOfType` (recommended over `sizeOf`/`alignment`)
+    and `Prim` class methods `sizeOfType#`/`alignmentOfType#` (recommended over `sizeOf#`/`alignment#`)
 
 ## Changes in version 0.8.0.0
 


### PR DESCRIPTION
* clarify that sizes are in bytes
* add an example to `sizeOfType`
* add missing version in `@since` annotations (from #371)
* add changelog entry for #371