### PR TITLE
Add Prim instance for Data.Complex (rebased)

### DIFF
--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -184,7 +184,7 @@ alignmentOfType = I# (alignmentOfType# (Proxy :: Proxy a))
 alignment :: Prim a => a -> Int
 alignment x = I# (alignment# x)
 
--- | @since 0.6.5.0
+-- | @since 0.9.0.0
 instance Prim a => Prim (Complex a) where
   sizeOf# _ = 2# *# sizeOf# (undefined :: a)
   alignment# _ = alignment# (undefined :: a)

--- a/Data/Primitive/Types.hs
+++ b/Data/Primitive/Types.hs
@@ -200,7 +200,6 @@ instance Prim a => Prim (Complex a) where
     \s0 -> case writeByteArray# arr# (2# *# i#) a s0 of
        s1 -> case writeByteArray# arr# (2# *# i# +# 1#) b s1 of
          s2 -> s2
-  setByteArray# = defaultSetByteArray#
   indexOffAddr# addr# i# =
     let x = indexOffAddr# addr# (2# *# i#)
         y = indexOffAddr# addr# (2# *# i# +# 1#)
@@ -213,17 +212,14 @@ instance Prim a => Prim (Complex a) where
     \s0 -> case writeOffAddr# addr# (2# *# i#) a s0 of
        s1 -> case writeOffAddr# addr# (2# *# i# +# 1#) b s1 of
          s2 -> s2
-  setOffAddr# = defaultSetOffAddr#
   {-# INLINE sizeOf# #-}
   {-# INLINE alignment# #-}
   {-# INLINE indexByteArray# #-}
   {-# INLINE readByteArray# #-}
   {-# INLINE writeByteArray# #-}
-  {-# INLINE setByteArray# #-}
   {-# INLINE indexOffAddr# #-}
   {-# INLINE readOffAddr# #-}
   {-# INLINE writeOffAddr# #-}
-  {-# INLINE setOffAddr# #-}
 
 -- | An implementation of 'setByteArray#' that calls 'writeByteArray#'
 -- to set each element. This is helpful when writing a 'Prim' instance

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
   * Use `mutableByteArrayContents#` in GHC 9.2+
 
+  * Add `Prim` instance for `Complex`.
+
   * Add `getSizeofSmallMutableArray` that wraps `getSizeofSmallMutableArray#`
     from `GHC.Exts`.
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -19,6 +19,7 @@
 
 import Control.Monad
 import Control.Monad.ST
+import Data.Complex
 import Data.Primitive
 import Data.Word
 import Data.Proxy (Proxy(..))
@@ -153,6 +154,9 @@ main = do
     , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
       ]
+    , testGroup "Complex"
+      [ lawsToTest (primLaws (Proxy :: Proxy (Complex Double)))
+      ]
 #if __GLASGOW_HASKELL__ >= 805
     , testGroup "PrimStorable"
       [ lawsToTest (QCC.storableLaws (Proxy :: Proxy Derived))
@@ -180,15 +184,29 @@ main = do
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
       ]
+    , testGroup "Newtypes"
+      [ lawsToTest (primLaws (Proxy :: Proxy (Const Int16 Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Down Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Identity Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Dual Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Sum Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Product Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.First Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
+      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
+      ]
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)
 -- Const, Dual, Sum, Product: all have Arbitrary instances defined
 -- in QuickCheck itself
+#if MIN_VERSION_base(4,9,0)
 deriving instance Arbitrary a => Arbitrary (Semigroup.First a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
+#endif
 
 word8 :: Proxy Word8
 word8 = Proxy

--- a/test/main.hs
+++ b/test/main.hs
@@ -154,9 +154,6 @@ main = do
     , testGroup "DefaultSetMethod"
       [ lawsToTest (primLaws (Proxy :: Proxy DefaultSetMethod))
       ]
-    , testGroup "Complex"
-      [ lawsToTest (primLaws (Proxy :: Proxy (Complex Double)))
-      ]
 #if __GLASGOW_HASKELL__ >= 805
     , testGroup "PrimStorable"
       [ lawsToTest (QCC.storableLaws (Proxy :: Proxy Derived))
@@ -183,30 +180,17 @@ main = do
       , renameLawsToTest "Last" (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
       , renameLawsToTest "Min" (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
       , renameLawsToTest "Max" (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
-      ]
-    , testGroup "Newtypes"
-      [ lawsToTest (primLaws (Proxy :: Proxy (Const Int16 Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Down Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Identity Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Dual Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Sum Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Monoid.Product Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.First Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Last Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Min Int16)))
-      , lawsToTest (primLaws (Proxy :: Proxy (Semigroup.Max Int16)))
+      , renameLawsToTest "Complex" (primLaws (Proxy :: Proxy (Complex Double)))
       ]
     ]
 
 deriving instance Arbitrary a => Arbitrary (Down a)
 -- Const, Dual, Sum, Product: all have Arbitrary instances defined
 -- in QuickCheck itself
-#if MIN_VERSION_base(4,9,0)
 deriving instance Arbitrary a => Arbitrary (Semigroup.First a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Last a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Min a)
 deriving instance Arbitrary a => Arbitrary (Semigroup.Max a)
-#endif
 
 word8 :: Proxy Word8
 word8 = Proxy


### PR DESCRIPTION
Addresses remaining issues with https://github.com/haskell/primitive/pull/381. I'm not able to force push to a branch in this repository. If anyone is able to change this, it would be great. I think that kind of protection is useful for the master branch but annoying for any of the other branches.