### PR TITLE
Change Show instances for Array, SmallArray, PrimArray

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -794,8 +794,8 @@ instance Read1 Array where
 #else
   -- This is just the default implementation of liftReadsPrec, but
   -- it is not present in older versions of base.
-  liftReadsPrec rp rl = readPrec_to_S $
-    liftReadPrec (readS_to_Prec rp) (readS_to_Prec (const rl))
+  liftReadsPrec rp rl = RdPrc.readPrec_to_S $
+    arrayLiftReadPrec (RdPrc.readS_to_Prec rp) (RdPrc.readS_to_Prec (const rl))
 #endif
 
 -- Note [Forgiving Array Read Instance]

--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -794,7 +794,7 @@ instance Read1 Array where
 #else
   -- This is just the default implementation of liftReadsPrec, but
   -- it is not present in older versions of base.
-  liftReadsPrec = liftReadsPrec rp rl = readPrec_to_S $
+  liftReadsPrec rp rl = readPrec_to_S $
     liftReadPrec (readS_to_Prec rp) (readS_to_Prec (const rl))
 #endif
 

--- a/Data/Primitive/Internal/Read.hs
+++ b/Data/Primitive/Internal/Read.hs
@@ -1,0 +1,26 @@
+module Data.Primitive.Internal.Read
+  ( Tag(..)
+  , lexTag
+  ) where
+
+import Text.ParserCombinators.ReadP
+
+data Tag = FromListTag | FromListNTag
+
+-- Why don't we just use lexP? The general problem with lexP is that
+-- it doesn't always fail as fast as we might like. It will
+-- happily read to the end of an absurdly long lexeme (e.g., a 200MB string
+-- literal) before returning, at which point we'll immediately discard
+-- the result because it's not an identifier. Doing the job ourselves, we
+-- can see very quickly when we've run into a problem. We should also get
+-- a slight efficiency boost by going through the string just once.
+lexTag :: ReadP Tag
+lexTag = do
+  _ <- string "fromList"
+  s <- look
+  case s of
+    'N':c:_
+      | '0' <= c && c <= '9'
+      -> fail "" -- We have fromListN3 or similar
+      | otherwise -> FromListNTag <$ get -- Skip the 'N'
+    _ -> return FromListTag

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -222,9 +222,7 @@ instance Prim a => IsList (PrimArray a) where
 
 -- | @since 0.6.4.0
 instance (Show a, Prim a) => Show (PrimArray a) where
-  showsPrec p a = showParen (p > 10) $
-    showString "fromListN " . shows (sizeofPrimArray a) . showString " "
-      . shows (primArrayToList a)
+  showsPrec _ a = shows (primArrayToList a)
 
 die :: String -> String -> a
 die fun problem = error $ "Data.Primitive.PrimArray." ++ fun ++ ": " ++ problem

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -899,8 +899,8 @@ instance Read1 SmallArray where
 #else
   -- This is just the default implementation of liftReadsPrec, but
   -- it is not present in older versions of base.
-  liftReadsPrec rp rl = readPrec_to_S $
-    liftReadPrec (readS_to_Prec rp) (readS_to_Prec (const rl))
+  liftReadsPrec rp rl = RdPrc.readPrec_to_S $
+    smallArrayLiftReadPrec (RdPrc.readS_to_Prec rp) (RdPrc.readS_to_Prec (const rl))
 #endif
 
 smallArrayDataType :: DataType

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -81,9 +81,13 @@ import Control.Monad.Zip
 import Data.Data
 import Data.Foldable as Foldable
 import Data.Functor.Identity
+import Data.Primitive.Internal.Read (Tag(..),lexTag)
+import Text.Read (Read (..), parens, prec)
 import qualified GHC.ST as GHCST
 import qualified Data.Semigroup as Sem
 import Text.ParserCombinators.ReadP
+import Text.ParserCombinators.ReadPrec (ReadPrec)
+import qualified Text.ParserCombinators.ReadPrec as RdPrc
 #if !MIN_VERSION_base(4,10,0)
 import GHC.Base (runRW#)
 #endif
@@ -856,9 +860,8 @@ instance IsList (SmallArray a) where
   toList = Foldable.toList
 
 smallArrayLiftShowsPrec :: (Int -> a -> ShowS) -> ([a] -> ShowS) -> Int -> SmallArray a -> ShowS
-smallArrayLiftShowsPrec elemShowsPrec elemListShowsPrec p sa = showParen (p > 10) $
-  showString "fromListN " . shows (length sa) . showString " "
-    . listLiftShowsPrec elemShowsPrec elemListShowsPrec 11 (toList sa)
+smallArrayLiftShowsPrec elemShowsPrec elemListShowsPrec _ sa =
+  listLiftShowsPrec elemShowsPrec elemListShowsPrec 11 (toList sa)
 
 -- this need to be included for older ghcs
 listLiftShowsPrec :: (Int -> a -> ShowS) -> ([a] -> ShowS) -> Int -> [a] -> ShowS
@@ -871,23 +874,34 @@ instance Show a => Show (SmallArray a) where
 instance Show1 SmallArray where
   liftShowsPrec = smallArrayLiftShowsPrec
 
-smallArrayLiftReadsPrec :: (Int -> ReadS a) -> ReadS [a] -> Int -> ReadS (SmallArray a)
-smallArrayLiftReadsPrec _ listReadsPrec p = readParen (p > 10) . readP_to_S $ do
-  () <$ string "fromListN"
-  skipSpaces
-  n <- readS_to_P reads
-  skipSpaces
-  l <- readS_to_P listReadsPrec
-  return $ smallArrayFromListN n l
+-- See Note [Forgiving Array Read Instance]
+smallArrayLiftReadPrec :: ReadPrec a -> ReadPrec [a] -> ReadPrec (SmallArray a)
+smallArrayLiftReadPrec _ read_list =
+  ( RdPrc.lift skipSpaces >> fmap fromList read_list )
+  RdPrc.+++
+  ( parens $ prec app_prec $ do
+      RdPrc.lift skipSpaces
+      tag <- RdPrc.lift lexTag
+      case tag of
+        FromListTag -> fromList <$> read_list
+        FromListNTag -> liftM2 fromListN readPrec read_list
+  )
+  where
+  app_prec = 10
 
 instance Read a => Read (SmallArray a) where
-  readsPrec = smallArrayLiftReadsPrec readsPrec readList
+  readPrec = smallArrayLiftReadPrec readPrec readListPrec
 
 -- | @since 0.6.4.0
 instance Read1 SmallArray where
-  liftReadsPrec = smallArrayLiftReadsPrec
-
-
+#if MIN_VERSION_base(4,10,0)
+  liftReadPrec = smallArrayLiftReadPrec
+#else
+  -- This is just the default implementation of liftReadsPrec, but
+  -- it is not present in older versions of base.
+  liftReadsPrec = liftReadsPrec rp rl = readPrec_to_S $
+    liftReadPrec (readS_to_Prec rp) (readS_to_Prec (const rl))
+#endif
 
 smallArrayDataType :: DataType
 smallArrayDataType =

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -899,7 +899,7 @@ instance Read1 SmallArray where
 #else
   -- This is just the default implementation of liftReadsPrec, but
   -- it is not present in older versions of base.
-  liftReadsPrec = liftReadsPrec rp rl = readPrec_to_S $
+  liftReadsPrec rp rl = readPrec_to_S $
     liftReadPrec (readS_to_Prec rp) (readS_to_Prec (const rl))
 #endif
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,16 @@
   * Add standalone `sizeOfType`/`alignmentOfType` (recommended over `sizeOf`/`alignment`)
     and `Prim` class methods `sizeOfType#`/`alignmentOfType#` (recommended over `sizeOf#`/`alignment#`)
 
+  * Change `Show` instances of `PrimArray`, `Array`, and `SmallArray`. These
+    previously used the `fromListN n [...]` form, but they now used the more
+    terse `[...]` form.
+
+  * Correct the `Read` instances of `Array` and `SmallArray`. These instances
+    are supposed to be able to handle all three of these forms: `fromList [...]`,
+    `fromListN n [...]`, and `[...]`. They had been rejected the last form, but
+    this mistake was discovered by the test suite when the Show instances were
+    changed.
+
 ## Changes in version 0.8.0.0
 
   * Add `resizeSmallMutableArray` that wraps `resizeSmallMutableArray#` from

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -53,6 +53,7 @@ Library
 
   Other-Modules:
         Data.Primitive.Internal.Operations
+        Data.Primitive.Internal.Read
 
   Build-Depends: base >= 4.9 && < 4.19
                , deepseq >= 1.1 && < 1.5


### PR DESCRIPTION
Resolves https://github.com/haskell/primitive/issues/388

Remarkably, this accidentally unearthed a mistake in the `Read` implementations for `Array` and `SmallArray`. Anyone interested in that can look at the diff. I rewrote the `Read` instance for `SmallArray` entirely to just copy what `Array` was doing.