### PR TITLE
Clarify that newly allocated `ByteArray`s/`PrimArray`s are uninitialized

### DIFF
--- a/Data/Primitive/ByteArray.hs
+++ b/Data/Primitive/ByteArray.hs
@@ -89,6 +89,7 @@ import System.IO.Unsafe (unsafeDupablePerformIO)
 import Data.Array.Byte (ByteArray(..), MutableByteArray(..))
 
 -- | Create a new mutable byte array of the specified size in bytes.
+-- The underlying memory is left uninitialized.
 --
 -- /Note:/ this function does not check if the input is non-negative.
 newByteArray :: PrimMonad m => Int -> m (MutableByteArray (PrimState m))
@@ -98,7 +99,7 @@ newByteArray (I# n#)
                         (# s'#, arr# #) -> (# s'#, MutableByteArray arr# #))
 
 -- | Create a /pinned/ byte array of the specified size in bytes. The garbage
--- collector is guaranteed not to move it.
+-- collector is guaranteed not to move it. The underlying memory is left uninitialized.
 --
 -- /Note:/ this function does not check if the input is non-negative.
 newPinnedByteArray :: PrimMonad m => Int -> m (MutableByteArray (PrimState m))
@@ -109,6 +110,7 @@ newPinnedByteArray (I# n#)
 
 -- | Create a /pinned/ byte array of the specified size in bytes and with the
 -- given alignment. The garbage collector is guaranteed not to move it.
+-- The underlying memory is left uninitialized.
 --
 -- /Note:/ this function does not check if the input is non-negative.
 newAlignedPinnedByteArray

--- a/Data/Primitive/PrimArray.hs
+++ b/Data/Primitive/PrimArray.hs
@@ -1074,7 +1074,7 @@ documentation of the @Data.Primitive@ module.
 -}
 
 -- | Create a /pinned/ primitive array of the specified size (in elements). The garbage
--- collector is guaranteed not to move it.
+-- collector is guaranteed not to move it. The underlying memory is left uninitialized.
 --
 -- @since 0.7.1.0
 newPinnedPrimArray :: forall m a. (PrimMonad m, Prim a)
@@ -1086,7 +1086,7 @@ newPinnedPrimArray (I# n#)
 
 -- | Create a /pinned/ primitive array of the specified size (in elements) and
 -- with the alignment given by its 'Prim' instance. The garbage collector is
--- guaranteed not to move it.
+-- guaranteed not to move it. The underlying memory is left uninitialized.
 --
 -- @since 0.7.0.0
 newAlignedPinnedPrimArray :: forall m a. (PrimMonad m, Prim a)


### PR DESCRIPTION
I just had a bug, because I assumed `ByteArray`s/`PrimArray`s were initialized with zeros. Unfortunately, the documentation didn't mention that they're uninitialized (except for `newPrimArray`).