### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -55,8 +55,8 @@ Library
         Data.Primitive.Internal.Operations
         Data.Primitive.Internal.Read
 
-  Build-Depends: base >= 4.9 && < 4.19
-               , deepseq >= 1.1 && < 1.5
+  Build-Depends: base >= 4.9 && < 4.20
+               , deepseq >= 1.1 && < 1.6
                , transformers >= 0.5 && < 0.7
                , template-haskell >= 2.11
 


### PR DESCRIPTION
Only makes the library itself build. The test suite has broken dependencies, some of which in turn have broken dependencies.