### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/primitive.cabal
+++ b/primitive.cabal
@@ -72,7 +72,6 @@ Library
 
   Include-Dirs: cbits
   Install-Includes: primitive-memops.h
-  includes: primitive-memops.h
   c-sources: cbits/primitive-memops.c
   if !os(solaris)
       cc-options: -ftree-vectorize


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355