### PR TITLE
Use `matrix.os` instead of `runner.os` in the CI cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         path: |
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}
+        key: ${{ matrix.os }}-${{ matrix.ghc }}
     - name: Build
       run: cabal build all --enable-tests
     - name: Test


### PR DESCRIPTION
`runner.os` typically has values like `Linux` or `Windows`, whereas `matrix.os` (which is the value of `runs-on`) has more descriptive values such as `ubuntu-24.04-arm`. In particular, `matrix.os` tends to contain or imply a particular OS version (e.g., `24.04`) and a particular architecture (e.g., x86_64 for `ubuntu-latest`, ARM64 for `ubuntu-latest-arm`). These data are highly relevant to compilation; they should be included in the cache key to avoid spurious sharing of caches between OS versions or architectures.

This is not currently a *problem* for `primitive`, as it is only tested against a single OS version and architecture. However, it never hurts to be future proof, especially since using `matrix.os` is just as easy as `runner.os`.