### PR TITLE
Deriving `Typeable` is redundant

### DIFF
--- a/Data/Primitive/Array.hs
+++ b/Data/Primitive/Array.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, MagicHash, UnboxedTuples, DeriveDataTypeable, BangPatterns #-}
+{-# LANGUAGE CPP, MagicHash, UnboxedTuples, BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -64,7 +64,6 @@ import Language.Haskell.TH.Syntax (Lift (..))
 -- | Boxed arrays.
 data Array a = Array
   { array# :: Array# a }
-  deriving ( Typeable )
 
 instance Lift a => Lift (Array a) where
 #if MIN_VERSION_template_haskell(2,16,0)
@@ -107,7 +106,6 @@ instance NFData a => NFData (Array a) where
 -- | Mutable boxed arrays associated with a primitive state token.
 data MutableArray s a = MutableArray
   { marray# :: MutableArray# s a }
-  deriving ( Typeable )
 
 -- | The number of elements in an immutable array.
 sizeofArray :: Array a -> Int

--- a/Data/Primitive/MutVar.hs
+++ b/Data/Primitive/MutVar.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash, UnboxedTuples, DeriveDataTypeable, CPP #-}
+{-# LANGUAGE MagicHash, UnboxedTuples, CPP #-}
 
 -- |
 -- Module      : Data.Primitive.MutVar
@@ -37,12 +37,10 @@ import GHC.STRef (STRef(STRef))
 import GHC.Exts ( MutVar#, sameMutVar#, newMutVar#
                 , readMutVar#, writeMutVar#, atomicModifyMutVar#
                 , isTrue#, RealWorld)
-import Data.Typeable ( Typeable )
 
 -- | A 'MutVar' behaves like a single-element mutable array associated
 -- with a primitive state token.
 data MutVar s a = MutVar (MutVar# s a)
-  deriving ( Typeable )
 
 instance Eq (MutVar s a) where
   MutVar mva# == MutVar mvb# = isTrue# (sameMutVar# mva# mvb#)

--- a/Data/Primitive/SmallArray.hs
+++ b/Data/Primitive/SmallArray.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
@@ -93,7 +92,6 @@ import Data.Functor.Classes (Eq1(..), Ord1(..), Show1(..), Read1(..))
 import Language.Haskell.TH.Syntax (Lift(..))
 
 data SmallArray a = SmallArray (SmallArray# a)
-  deriving Typeable
 
 #if MIN_VERSION_deepseq(1,4,3)
 instance NFData1 SmallArray where
@@ -104,7 +102,6 @@ instance NFData a => NFData (SmallArray a) where
   rnf = foldl' (\_ -> rnf) ()
 
 data SmallMutableArray s a = SmallMutableArray (SmallMutableArray# s a)
-  deriving Typeable
 
 instance Lift a => Lift (SmallArray a) where
 #if MIN_VERSION_template_haskell(2,16,0)

--- a/primitive.cabal
+++ b/primitive.cabal
@@ -38,7 +38,7 @@ Library
   Default-Extensions:
         TypeOperators
   Other-Extensions:
-        BangPatterns, CPP, DeriveDataTypeable,
+        BangPatterns, CPP,
         MagicHash, TypeFamilies, UnboxedTuples, UnliftedFFITypes
 
   Exposed-Modules:


### PR DESCRIPTION
All types automatically derive `Typeable` since GHC 7.10.