### PR TITLE
Fix signed fill arguments at the C FFI boundary

### DIFF
--- a/Data/Primitive/Internal/Operations.hs
+++ b/Data/Primitive/Internal/Operations.hs
@@ -70,12 +70,20 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setWordArray# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
 
 #if __GLASGOW_HASKELL__ >= 902
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
-  setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int8# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
-  setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int16# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
-  setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
+-- The C helpers take unsigned values. Some ABIs, such as RISC-V, require
+-- different extension of narrow signed and unsigned arguments. Convert to
+-- the C argument type before the FFI call to get the correct upper bits.
+setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int8# -> IO ()
+{-# INLINE setInt8Array# #-}
+setInt8Array# arr off n x = setWord8Array# arr off n (int8ToWord8# x)
+
+setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int16# -> IO ()
+{-# INLINE setInt16Array# #-}
+setInt16Array# arr off n x = setWord16Array# arr off n (int16ToWord16# x)
+
+setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
+{-# INLINE setInt32Array# #-}
+setInt32Array# arr off n x = setWord32Array# arr off n (int32ToWord32# x)
 #else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
@@ -123,12 +131,17 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word"
   setWordOffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
 
 #if __GLASGOW_HASKELL__ >= 902
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
-  setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int8# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
-  setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int16# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
-  setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
+setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int8# -> IO ()
+{-# INLINE setInt8OffAddr# #-}
+setInt8OffAddr# addr off n x = setWord8OffAddr# addr off n (int8ToWord8# x)
+
+setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int16# -> IO ()
+{-# INLINE setInt16OffAddr# #-}
+setInt16OffAddr# addr off n x = setWord16OffAddr# addr off n (int16ToWord16# x)
+
+setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
+{-# INLINE setInt32OffAddr# #-}
+setInt32OffAddr# addr off n x = setWord32OffAddr# addr off n (int32ToWord32# x)
 #else
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
   setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()

--- a/Data/Primitive/Internal/Operations.hs
+++ b/Data/Primitive/Internal/Operations.hs
@@ -56,11 +56,13 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setWord32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word32# -> IO ()
 #else
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+-- Before GHC 9.2 these values use Word#, so the C entry points must take
+-- a full machine word and perform the narrowing themselves.
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8_compat"
   setWord8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16_compat"
   setWord16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32_compat"
   setWord32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Word# -> IO ()
 #endif
 
@@ -85,12 +87,17 @@ setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
 {-# INLINE setInt32Array# #-}
 setInt32Array# arr off n x = setWord32Array# arr off n (int32ToWord32# x)
 #else
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
-  setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
-  setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
-  setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt8Array# #-}
+setInt8Array# arr off n x = setWord8Array# arr off n (int2Word# x)
+
+setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt16Array# #-}
+setInt16Array# arr off n x = setWord16Array# arr off n (int2Word# x)
+
+setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt32Array# #-}
+setInt32Array# arr off n x = setWord32Array# arr off n (int2Word# x)
 #endif
 
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"
@@ -117,11 +124,11 @@ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
   setWord32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word32# -> IO ()
 #else
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8_compat"
   setWord8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16_compat"
   setWord16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32_compat"
   setWord32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Word# -> IO ()
 #endif
 
@@ -143,12 +150,17 @@ setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
 {-# INLINE setInt32OffAddr# #-}
 setInt32OffAddr# addr off n x = setWord32OffAddr# addr off n (int32ToWord32# x)
 #else
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
-  setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
-  setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
-  setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt8OffAddr# #-}
+setInt8OffAddr# addr off n x = setWord8OffAddr# addr off n (int2Word# x)
+
+setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt16OffAddr# #-}
+setInt16OffAddr# addr off n x = setWord16OffAddr# addr off n (int2Word# x)
+
+setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int# -> IO ()
+{-# INLINE setInt32OffAddr# #-}
+setInt32OffAddr# addr off n x = setWord32OffAddr# addr off n (int2Word# x)
 #endif
 
 foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word64"

--- a/cbits/primitive-memops.c
+++ b/cbits/primitive-memops.c
@@ -64,3 +64,14 @@ MEMSET(Ptr, HsPtr)
 MEMSET_FLOAT(Float, HsFloat)
 MEMSET_FLOAT(Double, HsDouble)
 MEMSET(Char, HsChar)
+
+#define MEMSET_COMPAT(TYPE)                                                      \
+void hsprimitive_memset_ ## TYPE ## _compat                                      \
+    (Hs ## TYPE *p, ptrdiff_t off, size_t n, HsWord x)                           \
+{                                                                                \
+  hsprimitive_memset_ ## TYPE(p, off, n, (Hs ## TYPE)x);                         \
+}
+
+MEMSET_COMPAT(Word8)
+MEMSET_COMPAT(Word16)
+MEMSET_COMPAT(Word32)

--- a/cbits/primitive-memops.h
+++ b/cbits/primitive-memops.h
@@ -15,6 +15,10 @@ int  hsprimitive_memcmp_offset(HsWord8 *s1, HsInt off1, HsWord8 *s2, HsInt off2,
 void hsprimitive_memset_Word8(HsWord8 *, ptrdiff_t, size_t, HsWord8);
 void hsprimitive_memset_Word16(HsWord16 *, ptrdiff_t, size_t, HsWord16);
 void hsprimitive_memset_Word32(HsWord32 *, ptrdiff_t, size_t, HsWord32);
+/* GHC < 9.2 represents narrow integers as machine words. */
+void hsprimitive_memset_Word8_compat(HsWord8 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word16_compat(HsWord16 *, ptrdiff_t, size_t, HsWord);
+void hsprimitive_memset_Word32_compat(HsWord32 *, ptrdiff_t, size_t, HsWord);
 void hsprimitive_memset_Word64(HsWord64 *, ptrdiff_t, size_t, HsWord64);
 void hsprimitive_memset_Word(HsWord *, ptrdiff_t, size_t, HsWord);
 void hsprimitive_memset_Ptr(HsPtr *, ptrdiff_t, size_t, HsPtr);


### PR DESCRIPTION
The setInt8/16/32Array# and setInt8/16/32OffAddr# imports pass signed values to C helpers that expect unsigned arguments. On RISC-V, the calling convention requires different extension for signed and unsigned 16-bit values. Filling four Int16 elements with -2 can therefore produce [-2,-1,-1,-1].

For GHC 9.2 and newer, convert the narrow signed values to their unsigned equivalents and call the existing unsigned imports through inline wrappers. This preserves the element bits while matching the C argument types.

This fixes 13 failures in the existing test suite on riscv64: Int16 filling, replicatePrimArray, and ByteArray Set Range for Int16 and its newtype wrappers.